### PR TITLE
feat: Add loading skeletons to all views (Issue #17)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,7 @@ export default function HomePage() {
           vehicles={vehicles}
           maintenanceRecords={maintenanceRecords}
           upcomingMaintenance={upcomingMaintenance}
+          isLoading={dataLoading}
         />
       ) : (
         <LandingPage />

--- a/app/vehicles/[id]/maintenance/loading.tsx
+++ b/app/vehicles/[id]/maintenance/loading.tsx
@@ -1,0 +1,10 @@
+import { VehicleDetailSkeleton } from "@/components/skeletons/vehicle-detail-skeleton"
+import { Layout } from "@/components/layout/Layout"
+
+export default function VehicleMaintenanceLoading() {
+  return (
+    <Layout showHeader={true}>
+      <VehicleDetailSkeleton />
+    </Layout>
+  )
+}

--- a/app/vehicles/loading.tsx
+++ b/app/vehicles/loading.tsx
@@ -1,0 +1,10 @@
+import { VehiclesSkeleton } from "@/components/skeletons/vehicles-skeleton"
+import { Layout } from "@/components/layout/Layout"
+
+export default function VehiclesLoading() {
+  return (
+    <Layout showHeader={true}>
+      <VehiclesSkeleton />
+    </Layout>
+  )
+}

--- a/components/dashboard/Dashboard.tsx
+++ b/components/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { DashboardStats } from "@/components/dashboard/dashboard-stats"
 import { RecentActivity } from "@/components/dashboard/recent-activity"
 import { UpcomingMaintenance } from "@/components/dashboard/upcoming-maintenance"
 import { VehicleOverview } from "@/components/dashboard/vehicle-overview"
+import { DashboardSkeleton } from "@/components/skeletons/dashboard-skeleton"
 
 interface Vehicle {
   id: string
@@ -36,9 +37,14 @@ interface DashboardProps {
   vehicles: Vehicle[]
   maintenanceRecords: any[]
   upcomingMaintenance: any[]
+  isLoading?: boolean
 }
 
-export function Dashboard({ user, profile, vehicles, maintenanceRecords, upcomingMaintenance }: DashboardProps) {
+export function Dashboard({ user, profile, vehicles, maintenanceRecords, upcomingMaintenance, isLoading }: DashboardProps) {
+  if (isLoading) {
+    return <DashboardSkeleton />
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       {/* Welcome Section */}
@@ -64,19 +70,19 @@ export function Dashboard({ user, profile, vehicles, maintenanceRecords, upcomin
       </div>
 
       {/* Dashboard Stats */}
-      <DashboardStats vehicles={vehicles} maintenanceRecords={maintenanceRecords} />
+      <DashboardStats vehicles={vehicles} maintenanceRecords={maintenanceRecords} isLoading={isLoading} />
 
       {/* Main Content Grid */}
       <div className="mt-10 grid gap-8 lg:grid-cols-3">
         {/* Left Column - Vehicle Overview */}
         <div className="space-y-8 lg:col-span-2">
-          <VehicleOverview vehicles={vehicles} />
-          <RecentActivity maintenanceRecords={maintenanceRecords} />
+          <VehicleOverview vehicles={vehicles} isLoading={isLoading} />
+          <RecentActivity maintenanceRecords={maintenanceRecords} isLoading={isLoading} />
         </div>
 
         {/* Right Column - Upcoming Maintenance */}
         <div className="space-y-8">
-          <UpcomingMaintenance upcomingMaintenance={upcomingMaintenance} />
+          <UpcomingMaintenance upcomingMaintenance={upcomingMaintenance} isLoading={isLoading} />
         </div>
       </div>
     </div>

--- a/components/dashboard/dashboard-stats.tsx
+++ b/components/dashboard/dashboard-stats.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Car, Wrench, DollarSign, AlertTriangle } from "lucide-react"
 
 interface Vehicle {
@@ -19,9 +20,28 @@ interface MaintenanceRecord {
 interface DashboardStatsProps {
   vehicles: Vehicle[]
   maintenanceRecords: MaintenanceRecord[]
+  isLoading?: boolean
 }
 
-export function DashboardStats({ vehicles, maintenanceRecords }: DashboardStatsProps) {
+export function DashboardStats({ vehicles, maintenanceRecords, isLoading }: DashboardStatsProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-5 w-5 rounded-full" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+              <Skeleton className="mt-1.5 h-3 w-32" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    )
+  }
   const totalVehicles = vehicles.length
   const totalMaintenanceRecords = maintenanceRecords.length
 

--- a/components/dashboard/recent-activity.tsx
+++ b/components/dashboard/recent-activity.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Activity, Car } from "lucide-react"
 import Link from "next/link"
 
@@ -20,6 +21,7 @@ interface MaintenanceRecord {
 
 interface RecentActivityProps {
   maintenanceRecords: MaintenanceRecord[]
+  isLoading?: boolean
 }
 
 const maintenanceTypes = {
@@ -38,7 +40,40 @@ const maintenanceTypes = {
   other: "Otro",
 }
 
-export function RecentActivity({ maintenanceRecords }: RecentActivityProps) {
+export function RecentActivity({ maintenanceRecords, isLoading }: RecentActivityProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-5 rounded-full" />
+              <Skeleton className="h-5 w-36" />
+            </div>
+            <Skeleton className="h-8 w-24" />
+          </div>
+          <Skeleton className="mt-2 h-4 w-48" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4 rounded-xl border p-4">
+                <Skeleton className="h-10 w-10 rounded-xl" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-5 w-16 rounded-md" />
+                  </div>
+                  <Skeleton className="h-3 w-48" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("es-ES", {
       month: "short",

--- a/components/dashboard/upcoming-maintenance.tsx
+++ b/components/dashboard/upcoming-maintenance.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Calendar, AlertTriangle, CheckCircle, Car } from "lucide-react"
 import Link from "next/link"
 
@@ -20,6 +21,7 @@ interface UpcomingMaintenanceRecord {
 
 interface UpcomingMaintenanceProps {
   upcomingMaintenance: UpcomingMaintenanceRecord[]
+  isLoading?: boolean
 }
 
 const maintenanceTypes = {
@@ -38,7 +40,38 @@ const maintenanceTypes = {
   other: "Otro",
 }
 
-export function UpcomingMaintenance({ upcomingMaintenance }: UpcomingMaintenanceProps) {
+export function UpcomingMaintenance({ upcomingMaintenance, isLoading }: UpcomingMaintenanceProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-5 rounded-full" />
+            <Skeleton className="h-5 w-40" />
+          </div>
+          <Skeleton className="mt-2 h-4 w-48" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-4 rounded-xl border p-4">
+                <Skeleton className="h-10 w-10 rounded-xl" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-5 w-16 rounded-md" />
+                  </div>
+                  <Skeleton className="h-3 w-32" />
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("es-ES", {
       month: "short",

--- a/components/dashboard/vehicle-overview.tsx
+++ b/components/dashboard/vehicle-overview.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Car, Plus, Gauge } from "lucide-react"
 import Link from "next/link"
 import { formatMileage } from "@/lib/formatters"
@@ -19,9 +20,46 @@ interface Vehicle {
 
 interface VehicleOverviewProps {
   vehicles: Vehicle[]
+  isLoading?: boolean
 }
 
-export function VehicleOverview({ vehicles }: VehicleOverviewProps) {
+export function VehicleOverview({ vehicles, isLoading }: VehicleOverviewProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-5 rounded-full" />
+              <Skeleton className="h-5 w-28" />
+            </div>
+            <Skeleton className="h-8 w-20" />
+          </div>
+          <Skeleton className="mt-2 h-4 w-40" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between rounded-xl border p-4">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-10 w-10 rounded-xl" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-32" />
+                    <div className="flex gap-2">
+                      <Skeleton className="h-5 w-12 rounded-md" />
+                      <Skeleton className="h-5 w-20 rounded-md" />
+                    </div>
+                  </div>
+                </div>
+                <Skeleton className="h-4 w-20" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
   if (vehicles.length === 0) {
     return (
       <Card>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger, SheetClose } from "@/components/ui/sheet"
 import { useAuth, useData } from "@/contexts"
+import { HeaderSkeleton } from "@/components/skeletons/header-skeleton"
 
 export function Header() {
   const { user, profile, isLoading: authLoading, isLoggingOut, signOut } = useAuth()
@@ -66,24 +67,7 @@ export function Header() {
 
   // Mostrar skeleton durante la carga inicial para evitar parpadeo
   if (authLoading) {
-    return (
-      <header className="border-border/50 fixed top-0 right-0 left-0 z-50 border-b bg-white/80 backdrop-blur-md">
-        <div className="container mx-auto flex items-center justify-between px-4 py-4">
-          {/* Logo y nombre */}
-          <Link href="/" className="flex items-center gap-2 transition-opacity hover:opacity-80">
-            <Image src="/logo_keepel_grueso.svg" alt="Keepel" width={32} height={32} />
-            <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Keepel</h1>
-          </Link>
-
-          {/* Skeleton para el área de navegación */}
-          <div className="flex items-center gap-4">
-            <div className="hidden h-4 w-20 animate-pulse rounded-lg bg-slate-100 sm:block"></div>
-            <div className="h-8 w-24 animate-pulse rounded-lg bg-slate-100"></div>
-            <div className="h-8 w-8 animate-pulse rounded-full bg-slate-100"></div>
-          </div>
-        </div>
-      </header>
-    )
+    return <HeaderSkeleton />
   }
 
   return (

--- a/components/maintenance/maintenance-list.tsx
+++ b/components/maintenance/maintenance-list.tsx
@@ -3,11 +3,13 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Calendar, DollarSign, Gauge, MoreVertical, Edit, Trash2, AlertCircle, CheckCircle } from "lucide-react"
 import { EditMaintenanceDialog } from "./edit-maintenance-dialog"
 import { DeleteMaintenanceDialog } from "./delete-maintenance-dialog"
 import { useState } from "react"
+import { MaintenanceSkeleton } from "@/components/skeletons/maintenance-skeleton"
 
 interface MaintenanceRecord {
   id: string
@@ -25,6 +27,7 @@ interface MaintenanceRecord {
 interface MaintenanceListProps {
   records: MaintenanceRecord[]
   vehicleId: string
+  isLoading?: boolean
 }
 
 const maintenanceTypes = {
@@ -43,9 +46,13 @@ const maintenanceTypes = {
   other: "Otro",
 }
 
-export function MaintenanceList({ records, vehicleId }: MaintenanceListProps) {
+export function MaintenanceList({ records, vehicleId, isLoading }: MaintenanceListProps) {
   const [editingRecord, setEditingRecord] = useState<MaintenanceRecord | null>(null)
   const [deletingRecord, setDeletingRecord] = useState<MaintenanceRecord | null>(null)
+
+  if (isLoading) {
+    return <MaintenanceSkeleton />
+  }
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("es-ES", {

--- a/components/skeletons/dashboard-skeleton.tsx
+++ b/components/skeletons/dashboard-skeleton.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+export function DashboardSkeleton() {
+  return (
+    <div 
+      className="container mx-auto px-4 py-8"
+      aria-busy="true"
+      role="status"
+      aria-label="Cargando panel de control"
+    >
+      {/* Welcome Section Skeleton */}
+      <div className="mb-10 space-y-2">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-5 w-80" />
+      </div>
+
+      {/* Quick Actions Skeleton */}
+      <div className="mb-10 flex flex-wrap gap-3">
+        <Skeleton className="h-10 w-36 rounded-lg" />
+        <Skeleton className="h-10 w-40 rounded-lg" />
+      </div>
+
+      {/* Dashboard Stats Skeleton - 4 cards */}
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-5 w-5 rounded-full" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+              <Skeleton className="mt-1.5 h-3 w-32" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Main Content Grid Skeleton */}
+      <div className="mt-10 grid gap-8 lg:grid-cols-3">
+        {/* Left Column - 2/3 width */}
+        <div className="space-y-8 lg:col-span-2">
+          {/* Vehicle Overview Skeleton */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-5 rounded-full" />
+                  <Skeleton className="h-5 w-28" />
+                </div>
+                <Skeleton className="h-8 w-20" />
+              </div>
+              <Skeleton className="mt-2 h-4 w-40" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex items-center justify-between rounded-xl border p-4">
+                    <div className="flex items-center gap-4">
+                      <Skeleton className="h-10 w-10 rounded-xl" />
+                      <div className="space-y-2">
+                        <Skeleton className="h-4 w-32" />
+                        <div className="flex gap-2">
+                          <Skeleton className="h-5 w-12 rounded-md" />
+                          <Skeleton className="h-5 w-20 rounded-md" />
+                        </div>
+                      </div>
+                    </div>
+                    <Skeleton className="h-4 w-20" />
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Recent Activity Skeleton */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-5 rounded-full" />
+                  <Skeleton className="h-5 w-36" />
+                </div>
+                <Skeleton className="h-8 w-24" />
+              </div>
+              <Skeleton className="mt-2 h-4 w-48" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-4 rounded-xl border p-4">
+                    <Skeleton className="h-10 w-10 rounded-xl" />
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-5 w-16 rounded-md" />
+                      </div>
+                      <Skeleton className="h-3 w-48" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right Column - 1/3 width */}
+        <div className="space-y-8">
+          {/* Upcoming Maintenance Skeleton */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-5 rounded-full" />
+                <Skeleton className="h-5 w-40" />
+              </div>
+              <Skeleton className="mt-2 h-4 w-48" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex items-start gap-4 rounded-xl border p-4">
+                    <Skeleton className="h-10 w-10 rounded-xl" />
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-5 w-16 rounded-md" />
+                      </div>
+                      <Skeleton className="h-3 w-32" />
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/skeletons/header-skeleton.tsx
+++ b/components/skeletons/header-skeleton.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function HeaderSkeleton() {
+  return (
+    <header 
+      className="border-border/50 fixed top-0 right-0 left-0 z-50 border-b bg-white/80 backdrop-blur-md"
+      aria-busy="true"
+      role="status"
+      aria-label="Cargando navegación"
+    >
+      <div className="container mx-auto flex items-center justify-between px-4 py-4">
+        {/* Logo skeleton */}
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-8 rounded-lg" />
+          <Skeleton className="h-7 w-20" />
+        </div>
+
+        {/* Navigation skeleton */}
+        <div className="flex items-center gap-4">
+          <Skeleton className="hidden h-4 w-20 sm:block" />
+          <Skeleton className="h-8 w-24 rounded-lg" />
+          <Skeleton className="h-8 w-8 rounded-full" />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/skeletons/maintenance-skeleton.tsx
+++ b/components/skeletons/maintenance-skeleton.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+export function MaintenanceSkeleton() {
+  return (
+    <div 
+      className="space-y-4"
+      aria-busy="true"
+      role="status"
+      aria-label="Cargando mantenimientos"
+    >
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-10 w-10 rounded-lg" />
+                <div className="space-y-2">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              </div>
+              <Skeleton className="h-8 w-8 rounded-lg" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Description */}
+            <Skeleton className="h-4 w-full" />
+            
+            {/* Cost and Mileage row */}
+            <div className="flex flex-wrap gap-4">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+            </div>
+
+            {/* Next Service Section */}
+            <div className="border-border border-t pt-3">
+              <Skeleton className="mb-2 h-4 w-32" />
+              <div className="flex flex-wrap gap-2">
+                <Skeleton className="h-6 w-36 rounded-full" />
+                <Skeleton className="h-6 w-32 rounded-full" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/components/skeletons/vehicle-detail-skeleton.tsx
+++ b/components/skeletons/vehicle-detail-skeleton.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+export function VehicleDetailSkeleton() {
+  return (
+    <div 
+      className="container mx-auto px-4 py-8"
+      aria-busy="true"
+      role="status"
+      aria-label="Cargando detalles del vehículo"
+    >
+      {/* Back Button Skeleton */}
+      <Skeleton className="mb-4 h-10 w-40 rounded-lg" />
+
+      {/* Vehicle Header Card Skeleton */}
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="space-y-4">
+            {/* Vehicle Title Row */}
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-6 w-6 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-7 w-48" />
+                <div className="flex flex-wrap items-center gap-2 sm:gap-4">
+                  <Skeleton className="h-5 w-14 rounded-md" />
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              </div>
+            </div>
+
+            {/* Button Row */}
+            <div className="border-border/50 flex justify-end border-t pt-2">
+              <Skeleton className="h-9 w-full rounded-lg sm:w-48" />
+            </div>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Maintenance History Title Skeleton */}
+      <div className="mb-6 space-y-1">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-7 w-56" />
+        </div>
+        <Skeleton className="h-4 w-40" />
+      </div>
+
+      {/* Maintenance List Skeleton */}
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-32" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-8 w-8 rounded-lg" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Description */}
+              <Skeleton className="h-4 w-full" />
+              
+              {/* Cost and Mileage row */}
+              <div className="flex flex-wrap gap-4">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              </div>
+
+              {/* Next Service Section */}
+              <div className="border-border border-t pt-3">
+                <Skeleton className="mb-2 h-4 w-28" />
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-6 w-32 rounded-full" />
+                  <Skeleton className="h-6 w-28 rounded-full" />
+                </div>
+              </div>
+
+              {/* Notes Section */}
+              <div className="border-border border-t pt-3">
+                <Skeleton className="mb-1 h-4 w-12" />
+                <Skeleton className="h-4 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/skeletons/vehicles-skeleton.tsx
+++ b/components/skeletons/vehicles-skeleton.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+export function VehiclesSkeleton() {
+  return (
+    <div 
+      className="container mx-auto px-4 py-8"
+      aria-busy="true"
+      role="status"
+      aria-label="Cargando vehículos"
+    >
+      {/* Title Section Skeleton */}
+      <div className="mb-8 space-y-2">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-5 w-80" />
+      </div>
+
+      {/* 3-column Vehicle Cards Grid Skeleton */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-5 rounded-full" />
+                  <Skeleton className="h-5 w-32" />
+                </div>
+                <Skeleton className="h-8 w-8 rounded-lg" />
+              </div>
+              <Skeleton className="mt-2 h-5 w-12 rounded-md" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {/* Color row */}
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4 rounded-full" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+              
+              {/* License plate row */}
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-12" />
+                <Skeleton className="h-5 w-20 rounded-md" />
+              </div>
+              
+              {/* Mileage row */}
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              
+              {/* VIN row */}
+              <Skeleton className="h-3 w-40" />
+              
+              {/* Button */}
+              <div className="pt-2">
+                <Skeleton className="h-9 w-full rounded-lg" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Add Vehicle Button Skeleton */}
+      <div className="mt-6">
+        <Skeleton className="h-10 w-full rounded-lg sm:w-40" />
+      </div>
+    </div>
+  )
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
+}
+
+export { Skeleton }

--- a/components/vehicles/vehicles-list.tsx
+++ b/components/vehicles/vehicles-list.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Car, MoreVertical, Edit, Trash2, Calendar, Gauge } from "lucide-react"
 import { EditVehicleDialog } from "./edit-vehicle-dialog"
@@ -10,6 +11,7 @@ import { DeleteVehicleDialog } from "./delete-vehicle-dialog"
 import { useState } from "react"
 import Link from "next/link"
 import { formatMileage } from "@/lib/formatters"
+import { VehiclesSkeleton } from "@/components/skeletons/vehicles-skeleton"
 
 interface Vehicle {
   id: string
@@ -26,11 +28,16 @@ interface Vehicle {
 
 interface VehiclesListProps {
   vehicles: Vehicle[]
+  isLoading?: boolean
 }
 
-export function VehiclesList({ vehicles }: VehiclesListProps) {
+export function VehiclesList({ vehicles, isLoading }: VehiclesListProps) {
   const [editingVehicle, setEditingVehicle] = useState<Vehicle | null>(null)
   const [deletingVehicle, setDeletingVehicle] = useState<Vehicle | null>(null)
+
+  if (isLoading) {
+    return <VehiclesSkeleton />
+  }
 
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/contexts/DataContext.tsx
+++ b/contexts/DataContext.tsx
@@ -74,8 +74,8 @@ export function DataProvider({ children }: DataProviderProps) {
   const [maintenanceRecords, setMaintenanceRecords] = useState<MaintenanceRecord[]>([])
   const [upcomingMaintenance, setUpcomingMaintenance] = useState<any[]>([])
 
-  const [isVehiclesLoading, setIsVehiclesLoading] = useState(false)
-  const [isMaintenanceLoading, setIsMaintenanceLoading] = useState(false)
+  const [isVehiclesLoading, setIsVehiclesLoading] = useState(true)
+  const [isMaintenanceLoading, setIsMaintenanceLoading] = useState(true)
 
   const supabase = useSupabase()
 


### PR DESCRIPTION
## Summary
Add loading skeleton placeholders to all data-fetching views for better UX during data loading states.

## Changes
### New Components
- `components/ui/skeleton.tsx` - Base shadcn Skeleton primitive
- `components/skeletons/header-skeleton.tsx` - Header nav skeleton
- `components/skeletons/dashboard-skeleton.tsx` - Dashboard skeleton
- `components/skeletons/vehicles-skeleton.tsx` - Vehicles list skeleton
- `components/skeletons/vehicle-detail-skeleton.tsx` - Vehicle detail skeleton
- `components/skeletons/maintenance-skeleton.tsx` - Maintenance list skeleton
- `app/vehicles/loading.tsx` - Next.js streaming UI for /vehicles
- `app/vehicles/[id]/maintenance/loading.tsx` - Next.js streaming UI for vehicle maintenance

### Modified Files
- `contexts/DataContext.tsx` - isLoading flags start as true
- `app/page.tsx` - Passes isLoading to Dashboard
- `components/dashboard/*.tsx` - Added isLoading props + skeleton rendering
- `components/vehicles/vehicles-list.tsx` - Added isLoading support
- `components/maintenance/maintenance-list.tsx` - Added isLoading support
- `components/layout/Header.tsx` - Uses HeaderSkeleton component

## Testing
- [ ] Verify skeletons appear during initial data load
- [ ] Verify skeletons have proper dark mode support
- [ ] Verify accessibility (aria-busy, role=status)

Closes #17