### PR TITLE
feat: add scheduled_services data layer (Issue #13 - PR 1/3)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { useAuth, useData } from "@/contexts"
 
 export default function HomePage() {
   const { user, profile, isLoading: authLoading, signOut } = useAuth()
-  const { vehicles, maintenanceRecords, upcomingMaintenance, isLoading: dataLoading, refreshAll } = useData()
+  const { vehicles, maintenanceRecords, scheduledServices, isLoading: dataLoading, refreshAll } = useData()
 
   // Show loading screen only during initial auth check to prevent flash
   const showLoadingScreen = authLoading
@@ -29,7 +29,7 @@ export default function HomePage() {
           profile={profile}
           vehicles={vehicles}
           maintenanceRecords={maintenanceRecords}
-          upcomingMaintenance={upcomingMaintenance}
+          upcomingMaintenance={scheduledServices}
           isLoading={dataLoading}
         />
       ) : (

--- a/components/dashboard/Dashboard.tsx
+++ b/components/dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import { RecentActivity } from "@/components/dashboard/recent-activity"
 import { UpcomingMaintenance } from "@/components/dashboard/upcoming-maintenance"
 import { VehicleOverview } from "@/components/dashboard/vehicle-overview"
 import { DashboardSkeleton } from "@/components/skeletons/dashboard-skeleton"
+import type { ScheduledService } from "@/contexts"
 
 interface Vehicle {
   id: string
@@ -36,7 +37,7 @@ interface DashboardProps {
   profile: Profile | null
   vehicles: Vehicle[]
   maintenanceRecords: any[]
-  upcomingMaintenance: any[]
+  upcomingMaintenance: ScheduledService[]
   isLoading?: boolean
 }
 

--- a/components/dashboard/upcoming-maintenance.tsx
+++ b/components/dashboard/upcoming-maintenance.tsx
@@ -10,8 +10,10 @@ import Link from "next/link"
 interface UpcomingMaintenanceRecord {
   id: string
   type: string
-  next_service_date: string
-  vehicles: {
+  scheduled_date?: string
+  scheduled_mileage?: number
+  status: string
+  vehicles?: {
     make: string
     model: string
     year: number
@@ -128,8 +130,9 @@ export function UpcomingMaintenance({ upcomingMaintenance, isLoading }: Upcoming
       <CardContent>
         <div className="space-y-3">
           {upcomingMaintenance.slice(0, 5).map((maintenance) => {
-            const daysUntil = getDaysUntil(maintenance.next_service_date)
-            const overdue = isOverdue(maintenance.next_service_date)
+            const scheduledDate = maintenance.scheduled_date || ""
+            const daysUntil = scheduledDate ? getDaysUntil(scheduledDate) : null
+            const overdue = scheduledDate ? isOverdue(scheduledDate) : false
 
             return (
               <div
@@ -153,20 +156,27 @@ export function UpcomingMaintenance({ upcomingMaintenance, isLoading }: Upcoming
                       variant={overdue ? "destructive" : "secondary"}
                       className={`border-0 text-xs ${overdue ? "" : "bg-amber-100 text-amber-700"}`}
                     >
-                      {overdue ? "Vencido" : `${daysUntil} días`}
+                      {overdue ? "Vencido" : daysUntil !== null ? `${daysUntil} días` : "Programado"}
                     </Badge>
                   </div>
 
                   <div className="flex items-center gap-2 text-xs text-slate-500">
                     <Car className="h-3.5 w-3.5 text-slate-400" />
-                    <span>
-                      {maintenance.vehicles.make} {maintenance.vehicles.model} {maintenance.vehicles.year}
-                    </span>
-                    {maintenance.vehicles.license_plate && <span className="text-slate-300">•</span>}
-                    {maintenance.vehicles.license_plate && <span>{maintenance.vehicles.license_plate}</span>}
+                    {maintenance.vehicles && (
+                      <span>
+                        {maintenance.vehicles.make} {maintenance.vehicles.model} {maintenance.vehicles.year}
+                        {maintenance.vehicles.license_plate && <span className="text-slate-300"> •</span>}
+                        {maintenance.vehicles.license_plate && <span> {maintenance.vehicles.license_plate}</span>}
+                      </span>
+                    )}
                   </div>
 
-                  <div className="mt-1.5 text-xs text-slate-500">{formatDate(maintenance.next_service_date)}</div>
+                  <div className="mt-1.5 text-xs text-slate-500">
+                      {scheduledDate && formatDate(scheduledDate)}
+                      {maintenance.scheduled_mileage && (
+                        <span> &middot; {maintenance.scheduled_mileage.toLocaleString("es-ES")} km</span>
+                      )}
+                    </div>
                 </div>
               </div>
             )

--- a/contexts/DataContext.tsx
+++ b/contexts/DataContext.tsx
@@ -36,30 +36,64 @@ export interface MaintenanceRecord {
   }
 }
 
+export type ScheduledServiceStatus = "pending" | "completed" | "cancelled"
+
+export interface ScheduledService {
+  id: string
+  vehicle_id: string
+  user_id: string
+  type: string
+  description?: string
+  scheduled_date?: string
+  scheduled_mileage?: number
+  status: ScheduledServiceStatus
+  notes?: string
+  completed_record_id?: string
+  created_at: string
+  updated_at: string
+  vehicles?: {
+    make: string
+    model: string
+    year: number
+    license_plate?: string
+  }
+}
+
 interface DataContextType {
   // Data
   vehicles: Vehicle[]
   maintenanceRecords: MaintenanceRecord[]
-  upcomingMaintenance: any[]
+  scheduledServices: ScheduledService[]
 
   // Loading states
   isLoading: boolean
   isVehiclesLoading: boolean
   isMaintenanceLoading: boolean
+  isScheduledServicesLoading: boolean
 
   // Actions
   refreshAll: () => Promise<void>
   refreshVehicles: () => Promise<void>
   refreshMaintenance: () => Promise<void>
+  refreshScheduledServices: () => Promise<void>
 
-  // Optimistic updates
+  // Optimistic updates - Vehicles
   addVehicleOptimistic: (vehicle: Omit<Vehicle, "id" | "created_at" | "updated_at">) => Promise<void>
   updateVehicleOptimistic: (id: string, updates: Partial<Vehicle>) => Promise<void>
   deleteVehicleOptimistic: (id: string) => Promise<void>
 
+  // Optimistic updates - Maintenance
   addMaintenanceOptimistic: (record: Omit<MaintenanceRecord, "id" | "created_at" | "updated_at">) => Promise<void>
   updateMaintenanceOptimistic: (id: string, updates: Partial<MaintenanceRecord>) => Promise<void>
   deleteMaintenanceOptimistic: (id: string) => Promise<void>
+
+  // Optimistic updates - Scheduled Services
+  addScheduledServiceOptimistic: (
+    service: Omit<ScheduledService, "id" | "created_at" | "updated_at" | "vehicles">
+  ) => Promise<void>
+  updateScheduledServiceOptimistic: (id: string, updates: Partial<ScheduledService>) => Promise<void>
+  deleteScheduledServiceOptimistic: (id: string) => Promise<void>
+  completeScheduledServiceOptimistic: (id: string, completedRecordId: string) => Promise<void>
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined)
@@ -72,10 +106,11 @@ export function DataProvider({ children }: DataProviderProps) {
   const { user, isAuthenticated } = useAuth()
   const [vehicles, setVehicles] = useState<Vehicle[]>([])
   const [maintenanceRecords, setMaintenanceRecords] = useState<MaintenanceRecord[]>([])
-  const [upcomingMaintenance, setUpcomingMaintenance] = useState<any[]>([])
+  const [scheduledServices, setScheduledServices] = useState<ScheduledService[]>([])
 
   const [isVehiclesLoading, setIsVehiclesLoading] = useState(true)
   const [isMaintenanceLoading, setIsMaintenanceLoading] = useState(true)
+  const [isScheduledServicesLoading, setIsScheduledServicesLoading] = useState(true)
 
   const supabase = useSupabase()
 
@@ -162,19 +197,47 @@ export function DataProvider({ children }: DataProviderProps) {
     [supabase]
   )
 
-  const loadUpcomingMaintenance = useCallback(async (userId: string) => {
-    if (!userId) return
+  const loadScheduledServices = useCallback(
+    async (userId: string) => {
+      if (!userId) return
 
-    try {
-      // Future implementation for upcoming maintenance logic
-      setUpcomingMaintenance([])
-    } catch (error) {
-      console.error("Upcoming maintenance load error:", error)
-      setUpcomingMaintenance([])
-    }
-  }, [])
+      setIsScheduledServicesLoading(true)
+      try {
+        const { data, error } = await supabase
+          .from("scheduled_services")
+          .select(
+            `
+            *,
+            vehicles (
+              make,
+              model,
+              year,
+              license_plate
+            )
+          `
+          )
+          .eq("user_id", userId)
+          .eq("status", "pending")
+          .order("scheduled_date", { ascending: true, nullsFirst: true })
 
-  // Refresh functions
+        if (error) {
+          console.error("Error loading scheduled services:", error)
+          setScheduledServices([])
+        } else if (data) {
+          setScheduledServices(data as ScheduledService[])
+        } else {
+          setScheduledServices([])
+        }
+      } catch (error) {
+        console.error("Scheduled services load error:", error)
+        setScheduledServices([])
+      } finally {
+        setIsScheduledServicesLoading(false)
+      }
+    },
+    [supabase]
+  )
+
   const refreshVehicles = useCallback(async () => {
     if (user?.id) {
       await loadVehicles(user.id)
@@ -184,15 +247,24 @@ export function DataProvider({ children }: DataProviderProps) {
   const refreshMaintenance = useCallback(async () => {
     if (user?.id) {
       await loadMaintenanceRecords(user.id)
-      await loadUpcomingMaintenance(user.id)
     }
-  }, [user?.id, loadMaintenanceRecords, loadUpcomingMaintenance])
+  }, [user?.id, loadMaintenanceRecords])
+
+  const refreshScheduledServices = useCallback(async () => {
+    if (user?.id) {
+      await loadScheduledServices(user.id)
+    }
+  }, [user?.id, loadScheduledServices])
 
   const refreshAll = useCallback(async () => {
     if (user?.id) {
-      await Promise.all([loadVehicles(user.id), loadMaintenanceRecords(user.id), loadUpcomingMaintenance(user.id)])
+      await Promise.all([
+        loadVehicles(user.id),
+        loadMaintenanceRecords(user.id),
+        loadScheduledServices(user.id),
+      ])
     }
-  }, [user?.id, loadVehicles, loadMaintenanceRecords, loadUpcomingMaintenance])
+  }, [user?.id, loadVehicles, loadMaintenanceRecords, loadScheduledServices])
 
   // Optimistic update functions
   const addVehicleOptimistic = useCallback(
@@ -346,6 +418,114 @@ export function DataProvider({ children }: DataProviderProps) {
     [maintenanceRecords, supabase]
   )
 
+  const addScheduledServiceOptimistic = useCallback(
+    async (serviceData: Omit<ScheduledService, "id" | "created_at" | "updated_at" | "vehicles">) => {
+      if (!user?.id) return
+
+      const optimisticService: ScheduledService = {
+        id: `temp-${Date.now()}`,
+        ...serviceData,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+
+      setScheduledServices((prev) => [optimisticService, ...prev])
+
+      try {
+        const { data, error } = await supabase
+          .from("scheduled_services")
+          .insert({ ...serviceData, user_id: user.id })
+          .select(
+            `
+            *,
+            vehicles (
+              make,
+              model,
+              year,
+              license_plate
+            )
+          `
+          )
+          .single()
+
+        if (error) throw error
+
+        setScheduledServices((prev) => prev.map((s) => (s.id === optimisticService.id ? (data as ScheduledService) : s)))
+      } catch (error) {
+        setScheduledServices((prev) => prev.filter((s) => s.id !== optimisticService.id))
+        throw error
+      }
+    },
+    [user?.id, supabase]
+  )
+
+  const updateScheduledServiceOptimistic = useCallback(
+    async (id: string, updates: Partial<ScheduledService>) => {
+      setScheduledServices((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, ...updates, updated_at: new Date().toISOString() } : s))
+      )
+
+      try {
+        const { error } = await supabase.from("scheduled_services").update(updates).eq("id", id)
+
+        if (error) throw error
+
+        await refreshScheduledServices()
+      } catch (error) {
+        await refreshScheduledServices()
+        throw error
+      }
+    },
+    [supabase, refreshScheduledServices]
+  )
+
+  const deleteScheduledServiceOptimistic = useCallback(
+    async (id: string) => {
+      const serviceToDelete = scheduledServices.find((s) => s.id === id)
+
+      setScheduledServices((prev) => prev.filter((s) => s.id !== id))
+
+      try {
+        const { error } = await supabase.from("scheduled_services").delete().eq("id", id)
+
+        if (error) throw error
+      } catch (error) {
+        if (serviceToDelete) {
+          setScheduledServices((prev) => [serviceToDelete, ...prev])
+        }
+        throw error
+      }
+    },
+    [scheduledServices, supabase]
+  )
+
+  const completeScheduledServiceOptimistic = useCallback(
+    async (id: string, completedRecordId: string) => {
+      setScheduledServices((prev) =>
+        prev.map((s) =>
+          s.id === id
+            ? { ...s, status: "completed" as ScheduledServiceStatus, completed_record_id: completedRecordId, updated_at: new Date().toISOString() }
+            : s
+        )
+      )
+
+      try {
+        const { error } = await supabase
+          .from("scheduled_services")
+          .update({ status: "completed", completed_record_id: completedRecordId, updated_at: new Date().toISOString() })
+          .eq("id", id)
+
+        if (error) throw error
+
+        await refreshScheduledServices()
+      } catch (error) {
+        await refreshScheduledServices()
+        throw error
+      }
+    },
+    [supabase, refreshScheduledServices]
+  )
+
   // Load data when user changes - only once per auth state change
   const hasLoadedRef = React.useRef(false)
 
@@ -358,10 +538,11 @@ export function DataProvider({ children }: DataProviderProps) {
       hasLoadedRef.current = false
       setVehicles([])
       setMaintenanceRecords([])
-      setUpcomingMaintenance([])
+      setScheduledServices([])
       // Reset loading states
       setIsVehiclesLoading(false)
       setIsMaintenanceLoading(false)
+      setIsScheduledServicesLoading(false)
     }
   }, [isAuthenticated, user?.id])
 
@@ -369,25 +550,35 @@ export function DataProvider({ children }: DataProviderProps) {
     // Data
     vehicles,
     maintenanceRecords,
-    upcomingMaintenance,
+    scheduledServices,
 
     // Loading states
-    isLoading: isVehiclesLoading || isMaintenanceLoading,
+    isLoading: isVehiclesLoading || isMaintenanceLoading || isScheduledServicesLoading,
     isVehiclesLoading,
     isMaintenanceLoading,
+    isScheduledServicesLoading,
 
     // Actions
     refreshAll,
     refreshVehicles,
     refreshMaintenance,
+    refreshScheduledServices,
 
-    // Optimistic updates
+    // Optimistic updates - Vehicles
     addVehicleOptimistic,
     updateVehicleOptimistic,
     deleteVehicleOptimistic,
+
+    // Optimistic updates - Maintenance
     addMaintenanceOptimistic,
     updateMaintenanceOptimistic,
     deleteMaintenanceOptimistic,
+
+    // Optimistic updates - Scheduled Services
+    addScheduledServiceOptimistic,
+    updateScheduledServiceOptimistic,
+    deleteScheduledServiceOptimistic,
+    completeScheduledServiceOptimistic,
   }
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -7,4 +7,4 @@ export { SupabaseProvider, useSupabase } from "./SupabaseContext"
 // Types
 export type { AuthUser, Profile } from "./AuthContext"
 
-export type { Vehicle, MaintenanceRecord } from "./DataContext"
+export type { Vehicle, MaintenanceRecord, ScheduledService, ScheduledServiceStatus } from "./DataContext"

--- a/hooks/useDashboardData.tsx
+++ b/hooks/useDashboardData.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react"
 import { useSupabase } from "@/hooks/useSupabase"
 import { useAuth } from "@/hooks/useAuth"
+import type { ScheduledService } from "@/contexts"
 
 interface Vehicle {
   id: string
@@ -20,7 +21,7 @@ interface Vehicle {
 interface DashboardData {
   vehicles: Vehicle[]
   maintenanceRecords: any[]
-  upcomingMaintenance: any[]
+  upcomingMaintenance: ScheduledService[]
 }
 
 export function useDashboardData(): DashboardData & {
@@ -33,7 +34,7 @@ export function useDashboardData(): DashboardData & {
   const { user, profile, isLoading: authLoading, signOut } = useAuth()
   const [vehicles, setVehicles] = useState<Vehicle[]>([])
   const [maintenanceRecords, setMaintenanceRecords] = useState<any[]>([])
-  const [upcomingMaintenance, setUpcomingMaintenance] = useState<any[]>([])
+  const [upcomingMaintenance, setUpcomingMaintenance] = useState<ScheduledService[]>([])
   const [isDataLoading, setIsDataLoading] = useState(false)
   const supabase = useSupabase()
 
@@ -109,28 +110,28 @@ export function useDashboardData(): DashboardData & {
         thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30)
 
         const { data, error } = await supabase
-          .from("maintenance_records")
+          .from("scheduled_services")
           .select(
             `
-          *,
-          vehicles (
-            make,
-            model,
-            year,
-            license_plate
-          )
-        `
+            *,
+            vehicles (
+              make,
+              model,
+              year,
+              license_plate
+            )
+          `
           )
           .eq("user_id", userId)
-          .not("next_service_date", "is", null)
-          .lte("next_service_date", thirtyDaysFromNow.toISOString().split("T")[0])
-          .order("next_service_date", { ascending: true })
+          .eq("status", "pending")
+          .lte("scheduled_date", thirtyDaysFromNow.toISOString().split("T")[0])
+          .order("scheduled_date", { ascending: true, nullsFirst: true })
 
         if (error) {
           console.error("Upcoming maintenance error:", error)
           setUpcomingMaintenance([])
         } else if (data) {
-          setUpcomingMaintenance(data)
+          setUpcomingMaintenance(data as ScheduledService[])
         } else {
           setUpcomingMaintenance([])
         }

--- a/scripts/004_create_scheduled_services.sql
+++ b/scripts/004_create_scheduled_services.sql
@@ -1,0 +1,30 @@
+-- Create scheduled_services table
+-- Separates future service scheduling from historical maintenance records (Issue #13)
+
+CREATE TABLE IF NOT EXISTS public.scheduled_services (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  vehicle_id UUID NOT NULL REFERENCES public.vehicles(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL, -- 'oil_change', 'tire_rotation', 'brake_service', etc.
+  description TEXT,
+  scheduled_date DATE,
+  scheduled_mileage INTEGER,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed', 'cancelled')),
+  notes TEXT,
+  completed_record_id UUID REFERENCES public.maintenance_records(id) ON DELETE SET NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.scheduled_services ENABLE ROW LEVEL SECURITY;
+
+-- Create RLS policies for scheduled_services
+CREATE POLICY "scheduled_services_select_own" ON public.scheduled_services FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "scheduled_services_insert_own" ON public.scheduled_services FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "scheduled_services_update_own" ON public.scheduled_services FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "scheduled_services_delete_own" ON public.scheduled_services FOR DELETE USING (auth.uid() = user_id);
+
+-- Create indexes for dashboard queries
+CREATE INDEX idx_scheduled_services_user_status ON public.scheduled_services(user_id, status);
+CREATE INDEX idx_scheduled_services_pending_date ON public.scheduled_services(scheduled_date) WHERE status = 'pending';


### PR DESCRIPTION
## Summary

Establishes the data foundation for separating scheduled services from historical maintenance records (Issue #13). This is PR 1 of 3, focusing on the database schema, TypeScript types, and data access layer — no UI changes that break existing behavior.

## Changes

- **`scripts/004_create_scheduled_services.sql`**: New SQL migration creating `scheduled_services` table with RLS policies and indexes
- **`contexts/DataContext.tsx`**: Add `ScheduledService` type, `ScheduledServiceStatus` union type, and full CRUD (add/update/delete/complete) with optimistic updates. Replace `upcomingMaintenance` state with `scheduledServices`
- **`contexts/index.ts`**: Export new types (`ScheduledService`, `ScheduledServiceStatus`)
- **`hooks/useDashboardData.tsx`**: Query `scheduled_services` table instead of filtering `maintenance_records` by `next_service_date`
- **`components/dashboard/Dashboard.tsx`**: Type `upcomingMaintenance` prop as `ScheduledService[]`
- **`components/dashboard/upcoming-maintenance.tsx`**: Update interface to use `scheduled_date`/`scheduled_mileage` instead of `next_service_date`/`next_service_mileage`, handle optional `vehicles` relation
- **`app/page.tsx`**: Pass `scheduledServices` from `useData()` to Dashboard

## Testing

- `bun run type-check` passes cleanly
- The `scheduled_services` table needs to be created in Supabase by running `scripts/004_create_scheduled_services.sql` before deploying this code

## Related Issues

Part of #13 — this PR establishes the foundation. Follow-up PRs will handle UI components and migration/cleanup.

## Note

The `upcoming-maintenance.tsx` component is updated to accept the new `ScheduledService` shape but still renders with scheduled services data sourced from the new table. The old `next_service_date`/`next_service_mileage` columns in `maintenance_records` are still intact — they will be removed in PR 3.