### PR TITLE
fix: resolve dropdown dialog initialization error (Issue #13)

### DIFF
--- a/app/vehicles/[id]/maintenance/page.tsx
+++ b/app/vehicles/[id]/maintenance/page.tsx
@@ -2,17 +2,11 @@ import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import { MaintenanceList } from "@/components/maintenance/maintenance-list"
 import { AddMaintenanceDialog } from "@/components/maintenance/add-maintenance-dialog"
-import { ScheduleServiceDialog } from "@/components/maintenance/schedule-service-dialog"
+import { MaintenanceActionsDropdown } from "@/components/maintenance/maintenance-actions-dropdown"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { ArrowLeft, Car, Plus, Wrench, Gauge, Calendar, ChevronDown } from "lucide-react"
+import { ArrowLeft, Car, Plus, Wrench, Gauge } from "lucide-react"
 import Link from "next/link"
 import { Layout } from "../../../../components/layout/Layout"
 
@@ -82,36 +76,7 @@ export default async function VehicleMaintenancePage({ params }: PageProps) {
 
                 {/* Acciones: Registrar o Programar */}
                 <div className="border-border/50 flex justify-end border-t pt-2">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button className="bg-primary hover:bg-primary/90 w-full sm:w-auto">
-                        <Plus className="mr-2 h-4 w-4" />
-                        <span className="hidden sm:inline">Agregar</span>
-                        <span className="sm:hidden">Agregar</span>
-                        <ChevronDown className="ml-1 h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <AddMaintenanceDialog vehicleId={id}>
-                        <DropdownMenuItem
-                          className="cursor-pointer"
-                          onSelect={(e) => e.preventDefault()}
-                        >
-                          <Wrench className="mr-2 h-4 w-4" />
-                          Registrar Mantenimiento
-                        </DropdownMenuItem>
-                      </AddMaintenanceDialog>
-                      <ScheduleServiceDialog vehicleId={id}>
-                        <DropdownMenuItem
-                          className="cursor-pointer"
-                          onSelect={(e) => e.preventDefault()}
-                        >
-                          <Calendar className="mr-2 h-4 w-4" />
-                          Programar Servicio
-                        </DropdownMenuItem>
-                      </ScheduleServiceDialog>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  <MaintenanceActionsDropdown vehicleId={id} />
                 </div>
               </div>
             </CardHeader>

--- a/components/maintenance/add-maintenance-dialog.tsx
+++ b/components/maintenance/add-maintenance-dialog.tsx
@@ -22,8 +22,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Wrench, Loader2, Plus, X } from "lucide-react"
 
 interface AddMaintenanceDialogProps {
-  children: React.ReactNode
+  children?: React.ReactNode
   vehicleId: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 interface ServiceItem {
@@ -49,8 +51,10 @@ const maintenanceTypes = [
   { value: "other", label: "Otro" },
 ]
 
-export function AddMaintenanceDialog({ children, vehicleId }: AddMaintenanceDialogProps) {
-  const [open, setOpen] = useState(false)
+export function AddMaintenanceDialog({ children, vehicleId, open: controlledOpen, onOpenChange }: AddMaintenanceDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen
+  const setOpen = onOpenChange ?? setInternalOpen
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -179,7 +183,7 @@ export function AddMaintenanceDialog({ children, vehicleId }: AddMaintenanceDial
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      {children && <DialogTrigger asChild>{children}</DialogTrigger>}
       <DialogContent className="sm:max-w-[600px]">
         <DialogHeader className="space-y-2">
           <DialogTitle className="flex items-center gap-2 text-lg">

--- a/components/maintenance/maintenance-actions-dropdown.tsx
+++ b/components/maintenance/maintenance-actions-dropdown.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { AddMaintenanceDialog } from "@/components/maintenance/add-maintenance-dialog"
+import { ScheduleServiceDialog } from "@/components/maintenance/schedule-service-dialog"
+import { Plus, Wrench, Calendar } from "lucide-react"
+
+interface MaintenanceActionsDropdownProps {
+  vehicleId: string
+}
+
+export function MaintenanceActionsDropdown({ vehicleId }: MaintenanceActionsDropdownProps) {
+  const [addOpen, setAddOpen] = useState(false)
+  const [scheduleOpen, setScheduleOpen] = useState(false)
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button className="bg-primary hover:bg-primary/90 w-full sm:w-auto">
+            <Plus className="mr-2 h-4 w-4" />
+            <span className="hidden sm:inline">Agregar</span>
+            <span className="sm:hidden">Agregar</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => setAddOpen(true)}>
+            <Wrench className="mr-2 h-4 w-4" />
+            Registrar Mantenimiento
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setScheduleOpen(true)}>
+            <Calendar className="mr-2 h-4 w-4" />
+            Programar Servicio
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AddMaintenanceDialog vehicleId={vehicleId} open={addOpen} onOpenChange={setAddOpen}>
+        <span />
+      </AddMaintenanceDialog>
+      <ScheduleServiceDialog vehicleId={vehicleId} open={scheduleOpen} onOpenChange={setScheduleOpen}>
+        <span />
+      </ScheduleServiceDialog>
+    </>
+  )
+}

--- a/components/maintenance/schedule-service-dialog.tsx
+++ b/components/maintenance/schedule-service-dialog.tsx
@@ -20,8 +20,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Calendar, Loader2 } from "lucide-react"
 
 interface ScheduleServiceDialogProps {
-  children: React.ReactNode
+  children?: React.ReactNode
   vehicleId: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 const maintenanceTypes = [
@@ -40,8 +42,10 @@ const maintenanceTypes = [
   { value: "other", label: "Otro" },
 ]
 
-export function ScheduleServiceDialog({ children, vehicleId }: ScheduleServiceDialogProps) {
-  const [open, setOpen] = useState(false)
+export function ScheduleServiceDialog({ children, vehicleId, open: controlledOpen, onOpenChange }: ScheduleServiceDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen
+  const setOpen = onOpenChange ?? setInternalOpen
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -122,7 +126,7 @@ export function ScheduleServiceDialog({ children, vehicleId }: ScheduleServiceDi
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      {children && <DialogTrigger asChild>{children}</DialogTrigger>}
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader className="space-y-2">
           <DialogTitle className="flex items-center gap-2 text-lg">


### PR DESCRIPTION
## Summary

Fixes the "Error de inicialización" that appears when opening the dropdown menu to add maintenance or schedule a service.

## Root Cause

Radix UI doesn't allow nesting interactive triggers — a `DialogTrigger` (from the dialog components) was placed inside a `DropdownMenuItem`, causing a hydration/rendering conflict.

## Fix

- Extracted `MaintenanceActionsDropdown` as a new client component that manages dialog open state externally via controlled `open`/`onOpenChange` props
- `AddMaintenanceDialog` and `ScheduleServiceDialog` now support controlled props alongside the existing `children` trigger pattern
- `DialogTrigger` is rendered conditionally — only when `children` are provided
- The dropdown items simply call `setAddOpen(true)` / `setScheduleOpen(true)` on `onSelect`

## Testing

- `bun run type-check` passes
- Dropdown now opens correctly without initialization errors
- Both "Registrar Mantenimiento" and "Programar Servicio" dialogs open from the dropdown
- The standalone "Agregar Primer Mantenimiento" button on empty state still works