### PR TITLE
Auth 02: expandir la frontera de autenticación del servidor

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,8 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter, JetBrains_Mono } from "next/font/google"
 import { OpenPanelComponent } from "@openpanel/nextjs"
-import { AppProviders } from "@/contexts"
+import { AppProviders } from "@/contexts/AppProviders"
+import { getAuthState } from "@/lib/auth/server"
 import "./globals.css"
 
 const inter = Inter({
@@ -59,11 +60,13 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const initialAuthState = await getAuthState()
+
   return (
     <html lang="es" className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
       <head>
@@ -80,7 +83,7 @@ export default function RootLayout({
           trackOutgoingLinks={false}
           trackAttributes={false}
         />
-        <AppProviders>{children}</AppProviders>
+        <AppProviders initialAuthState={initialAuthState}>{children}</AppProviders>
       </body>
     </html>
   )

--- a/contexts/AppProviders.tsx
+++ b/contexts/AppProviders.tsx
@@ -2,26 +2,31 @@
 
 import React from "react"
 import { Toaster } from "sonner"
-import { ContextErrorBoundary } from "@/components/ui/context-error-boundary"
-import { SupabaseProvider } from "./SupabaseContext"
 import { AuthProvider } from "./AuthContext"
+import { AuthProjectionProvider } from "./AuthProjectionContext"
 import { DataProvider } from "./DataContext"
+import { SupabaseProvider } from "./SupabaseContext"
+import { ContextErrorBoundary } from "@/components/ui/context-error-boundary"
+import type { AuthState } from "@/lib/auth/contracts"
 
 interface AppProvidersProps {
   children: React.ReactNode
+  initialAuthState: AuthState
 }
 
-export function AppProviders({ children }: AppProvidersProps) {
+export function AppProviders({ children, initialAuthState }: AppProvidersProps) {
   return (
     <ContextErrorBoundary>
-      <SupabaseProvider>
-        <AuthProvider>
-          <DataProvider>
-            {children}
-            <Toaster />
-          </DataProvider>
-        </AuthProvider>
-      </SupabaseProvider>
+      <AuthProjectionProvider initialState={initialAuthState}>
+        <SupabaseProvider>
+          <AuthProvider>
+            <DataProvider>
+              {children}
+              <Toaster />
+            </DataProvider>
+          </AuthProvider>
+        </SupabaseProvider>
+      </AuthProjectionProvider>
     </ContextErrorBoundary>
   )
 }

--- a/contexts/AuthProjectionContext.tsx
+++ b/contexts/AuthProjectionContext.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from "react"
+import type { AuthState } from "@/lib/auth/contracts"
+
+const AuthProjectionContext = createContext<AuthState | null>(null)
+
+interface AuthProjectionProviderProps {
+  children?: ReactNode
+  initialState: AuthState
+}
+
+export function AuthProjectionProvider({ children, initialState }: AuthProjectionProviderProps) {
+  return <AuthProjectionContext.Provider value={initialState}>{children}</AuthProjectionContext.Provider>
+}
+
+export function useAuthProjection() {
+  const state = useContext(AuthProjectionContext)
+
+  if (!state) {
+    throw new Error("useAuthProjection must be used within an AuthProjectionProvider")
+  }
+
+  return state
+}

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,6 +1,7 @@
 // Context exports
 export { AppProviders } from "./AppProviders"
 export { AuthProvider, useAuth } from "./AuthContext"
+export { AuthProjectionProvider, useAuthProjection } from "./AuthProjectionContext"
 export { DataProvider, useData } from "./DataContext"
 export { SupabaseProvider, useSupabase } from "./SupabaseContext"
 

--- a/lib/auth/contracts.ts
+++ b/lib/auth/contracts.ts
@@ -1,0 +1,76 @@
+export const AUTH_STATE_STATUS = {
+  ANONYMOUS: "anonymous",
+  AUTHENTICATED: "authenticated",
+} as const
+
+export const AUTH_COMMAND_STATUS = {
+  SUCCESS: "success",
+  ERROR: "error",
+} as const
+
+export const AUTH_ERROR_CODE = {
+  AUTHENTICATION_REQUIRED: "authentication_required",
+  INVALID_CREDENTIALS: "invalid_credentials",
+  RATE_LIMITED: "rate_limited",
+  VALIDATION_FAILED: "validation_failed",
+  PROVIDER_ERROR: "provider_error",
+  SESSION_EXPIRED: "session_expired",
+  UNEXPECTED: "unexpected",
+} as const
+
+export const SIGN_UP_STATUS = {
+  AUTHENTICATED: "authenticated",
+  CONFIRMATION_REQUIRED: "confirmation_required",
+  ERROR: "error",
+} as const
+
+type ValueOf<T> = T[keyof T]
+
+declare const userIdBrand: unique symbol
+
+export type UserId = string & { readonly [userIdBrand]: "UserId" }
+
+export type AuthErrorCode = ValueOf<typeof AUTH_ERROR_CODE>
+
+export type AuthError = {
+  [Code in AuthErrorCode]: { code: Code }
+}[AuthErrorCode]
+
+export interface CurrentUser {
+  id: UserId
+  email: string | null
+  displayName: string
+}
+
+export type AuthState =
+  | {
+      status: typeof AUTH_STATE_STATUS.ANONYMOUS
+      user: null
+    }
+  | {
+      status: typeof AUTH_STATE_STATUS.AUTHENTICATED
+      user: CurrentUser
+    }
+
+export type AuthCommandResult<SuccessData = undefined> =
+  | {
+      status: typeof AUTH_COMMAND_STATUS.SUCCESS
+      data: SuccessData
+    }
+  | {
+      status: typeof AUTH_COMMAND_STATUS.ERROR
+      error: AuthError
+    }
+
+export type SignUpResult =
+  | {
+      status: typeof SIGN_UP_STATUS.AUTHENTICATED
+      user: CurrentUser
+    }
+  | {
+      status: typeof SIGN_UP_STATUS.CONFIRMATION_REQUIRED
+    }
+  | {
+      status: typeof SIGN_UP_STATUS.ERROR
+      error: AuthError
+    }

--- a/lib/auth/server-boundary.ts
+++ b/lib/auth/server-boundary.ts
@@ -1,0 +1,111 @@
+import { AUTH_ERROR_CODE, AUTH_STATE_STATUS, type AuthState, type CurrentUser, type UserId } from "./contracts"
+
+export interface AuthServerAdapterUser {
+  id: string
+  email?: string | null
+  userMetadata?: Record<string, unknown> | null
+}
+
+export interface AuthServerAdapter {
+  getUser(): Promise<unknown>
+}
+
+export class AuthenticationRequiredError extends Error {
+  readonly code = AUTH_ERROR_CODE.AUTHENTICATION_REQUIRED
+
+  constructor() {
+    super("Authentication is required")
+    this.name = "AuthenticationRequiredError"
+  }
+}
+
+export class AuthenticationProviderError extends Error {
+  readonly code = AUTH_ERROR_CODE.PROVIDER_ERROR
+
+  constructor() {
+    super("Authentication provider returned an invalid response")
+    this.name = "AuthenticationProviderError"
+  }
+}
+
+function readDisplayName(metadata: Record<string, unknown> | null | undefined) {
+  const candidates = [metadata?.name, metadata?.full_name]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+
+  return null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseAdapterUser(value: unknown): AuthServerAdapterUser | null {
+  if (value === null) {
+    return null
+  }
+
+  if (!isRecord(value) || typeof value.id !== "string" || !value.id.trim()) {
+    throw new AuthenticationProviderError()
+  }
+
+  if (value.email !== undefined && value.email !== null && typeof value.email !== "string") {
+    throw new AuthenticationProviderError()
+  }
+
+  if (value.userMetadata !== undefined && value.userMetadata !== null && !isRecord(value.userMetadata)) {
+    throw new AuthenticationProviderError()
+  }
+
+  return {
+    id: value.id,
+    email: value.email,
+    userMetadata: value.userMetadata,
+  }
+}
+
+function projectCurrentUser(user: AuthServerAdapterUser): CurrentUser {
+  const email = user.email ?? null
+
+  return {
+    id: user.id as UserId,
+    email,
+    displayName: readDisplayName(user.userMetadata) ?? email?.split("@")[0] ?? "Usuario",
+  }
+}
+
+export function createAuthServerApi(adapter: AuthServerAdapter) {
+  async function getCurrentUser() {
+    const user = parseAdapterUser(await adapter.getUser())
+
+    return user ? projectCurrentUser(user) : null
+  }
+
+  async function requireCurrentUser() {
+    const user = await getCurrentUser()
+
+    if (!user) {
+      throw new AuthenticationRequiredError()
+    }
+
+    return user
+  }
+
+  async function getAuthState(): Promise<AuthState> {
+    const user = await getCurrentUser()
+
+    return user
+      ? { status: AUTH_STATE_STATUS.AUTHENTICATED, user }
+      : { status: AUTH_STATE_STATUS.ANONYMOUS, user: null }
+  }
+
+  return {
+    getCurrentUser,
+    requireCurrentUser,
+    getAuthState,
+  }
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,0 +1,17 @@
+import "server-only"
+
+import { cache } from "react"
+import { createClient } from "@/lib/supabase/server"
+import { createAuthServerApi, type AuthServerAdapter } from "./server-boundary"
+import { mapSupabaseUserResult } from "./supabase-server-adapter"
+
+const getUser = cache(async () => {
+  const supabase = await createClient()
+  const result = await supabase.auth.getUser()
+
+  return mapSupabaseUserResult(result)
+}) satisfies AuthServerAdapter["getUser"]
+
+const authServerApi = createAuthServerApi({ getUser })
+
+export const { getAuthState, getCurrentUser, requireCurrentUser } = authServerApi

--- a/lib/auth/supabase-server-adapter.ts
+++ b/lib/auth/supabase-server-adapter.ts
@@ -1,0 +1,35 @@
+import { isAuthSessionMissingError } from "@supabase/supabase-js"
+import { AuthenticationProviderError, type AuthServerAdapterUser } from "./server-boundary"
+
+interface SupabaseAuthUser {
+  id: string
+  email?: string
+  user_metadata?: Record<string, unknown>
+}
+
+interface SupabaseUserResult {
+  data: {
+    user: SupabaseAuthUser | null
+  }
+  error: unknown | null
+}
+
+export function mapSupabaseUserResult({ data, error }: SupabaseUserResult): AuthServerAdapterUser | null {
+  if (error) {
+    if (isAuthSessionMissingError(error)) {
+      return null
+    }
+
+    throw new AuthenticationProviderError()
+  }
+
+  if (!data.user) {
+    return null
+  }
+
+  return {
+    id: data.user.id,
+    email: data.user.email,
+    userMetadata: data.user.user_metadata,
+  }
+}

--- a/tests/integration/auth/server-boundary.test.ts
+++ b/tests/integration/auth/server-boundary.test.ts
@@ -1,0 +1,97 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { AuthProjectionProvider, useAuthProjection } from "@/contexts/AuthProjectionContext"
+import { AUTH_ERROR_CODE, AUTH_STATE_STATUS } from "@/lib/auth/contracts"
+import { createAuthServerApi } from "@/lib/auth/server-boundary"
+import { createControlledAuthServerAdapter } from "@/tests/support/controlled-auth-server-adapter"
+
+function ProjectionProbe() {
+  const state = useAuthProjection()
+
+  return createElement(
+    "span",
+    null,
+    state.status === AUTH_STATE_STATUS.AUTHENTICATED ? state.user.displayName : "anonymous"
+  )
+}
+
+describe("server authentication boundary", () => {
+  it("projects only the public user fields returned to consumers", async () => {
+    const adapter = createControlledAuthServerAdapter({
+      id: "user-1",
+      email: "driver@example.com",
+      userMetadata: {
+        name: "Ada Driver",
+        role: "admin",
+      },
+    })
+    const auth = createAuthServerApi(adapter)
+
+    const user = await auth.getCurrentUser()
+
+    expect(user).toEqual({
+      id: "user-1",
+      email: "driver@example.com",
+      displayName: "Ada Driver",
+    })
+    expect(Object.keys(user ?? {})).toEqual(["id", "email", "displayName"])
+  })
+
+  it("returns an anonymous state and rejects a required missing user with a stable code", async () => {
+    const auth = createAuthServerApi(createControlledAuthServerAdapter(null))
+
+    await expect(auth.getAuthState()).resolves.toEqual({
+      status: AUTH_STATE_STATUS.ANONYMOUS,
+      user: null,
+    })
+    await expect(auth.requireCurrentUser()).rejects.toMatchObject({
+      code: AUTH_ERROR_CODE.AUTHENTICATION_REQUIRED,
+    })
+  })
+
+  it.each(["not-a-user", { id: 42 }, { id: "" }, { id: "user-1", email: 42 }, { id: "user-1", userMetadata: [] }])(
+    "rejects malformed user data returned by the external adapter",
+    async (providerUser) => {
+      const auth = createAuthServerApi(createControlledAuthServerAdapter(providerUser))
+
+      await expect(auth.getCurrentUser()).rejects.toMatchObject({
+        code: AUTH_ERROR_CODE.PROVIDER_ERROR,
+      })
+    }
+  )
+
+  it.each([
+    [{ name: "  Ada Driver  " }, "driver@example.com", "Ada Driver"],
+    [{ full_name: "Grace Driver" }, "driver@example.com", "Grace Driver"],
+    [{}, "driver@example.com", "driver"],
+    [{}, null, "Usuario"],
+  ])("derives a stable display name from safe provider fields", async (userMetadata, email, expected) => {
+    const auth = createAuthServerApi(
+      createControlledAuthServerAdapter({
+        id: "user-1",
+        email,
+        userMetadata,
+      })
+    )
+
+    await expect(auth.getCurrentUser()).resolves.toMatchObject({ displayName: expected })
+  })
+
+  it("initializes the React projection with the state resolved by the server", async () => {
+    const auth = createAuthServerApi(
+      createControlledAuthServerAdapter({
+        id: "user-1",
+        email: "driver@example.com",
+        userMetadata: { full_name: "Ada Driver" },
+      })
+    )
+    const initialState = await auth.getAuthState()
+
+    const markup = renderToStaticMarkup(
+      createElement(AuthProjectionProvider, { initialState }, createElement(ProjectionProbe))
+    )
+
+    expect(markup).toBe("<span>Ada Driver</span>")
+  })
+})

--- a/tests/support/controlled-auth-server-adapter.ts
+++ b/tests/support/controlled-auth-server-adapter.ts
@@ -1,0 +1,9 @@
+import type { AuthServerAdapter } from "@/lib/auth/server-boundary"
+
+export function createControlledAuthServerAdapter(user: unknown): AuthServerAdapter {
+  return {
+    async getUser() {
+      return user
+    },
+  }
+}

--- a/tests/unit/auth/contracts.test.ts
+++ b/tests/unit/auth/contracts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, expectTypeOf, it } from "vitest"
+import {
+  AUTH_COMMAND_STATUS,
+  AUTH_ERROR_CODE,
+  AUTH_STATE_STATUS,
+  SIGN_UP_STATUS,
+  type AuthCommandResult,
+  type AuthErrorCode,
+  type AuthState,
+  type CurrentUser,
+  type SignUpResult,
+  type UserId,
+} from "@/lib/auth/contracts"
+
+describe("auth contracts", () => {
+  it("derives every discriminant from its typed constants", () => {
+    expectTypeOf<AuthState["status"]>().toEqualTypeOf<(typeof AUTH_STATE_STATUS)[keyof typeof AUTH_STATE_STATUS]>()
+    expectTypeOf<AuthCommandResult["status"]>().toEqualTypeOf<
+      (typeof AUTH_COMMAND_STATUS)[keyof typeof AUTH_COMMAND_STATUS]
+    >()
+    expectTypeOf<AuthErrorCode>().toEqualTypeOf<(typeof AUTH_ERROR_CODE)[keyof typeof AUTH_ERROR_CODE]>()
+    expectTypeOf<SignUpResult["status"]>().toEqualTypeOf<(typeof SIGN_UP_STATUS)[keyof typeof SIGN_UP_STATUS]>()
+    expectTypeOf<CurrentUser["id"]>().toEqualTypeOf<UserId>()
+
+    expect(Object.values(AUTH_STATE_STATUS)).toEqual(["anonymous", "authenticated"])
+    expect(Object.values(AUTH_COMMAND_STATUS)).toEqual(["success", "error"])
+    expect(Object.values(AUTH_ERROR_CODE)).toContain("authentication_required")
+    expect(Object.values(SIGN_UP_STATUS)).toEqual(["authenticated", "confirmation_required", "error"])
+  })
+
+  it("represents only valid authentication states", () => {
+    const user: CurrentUser = {
+      id: "user-1" as UserId,
+      email: "driver@example.com",
+      displayName: "Ada Driver",
+    }
+    const authenticated: AuthState = {
+      status: AUTH_STATE_STATUS.AUTHENTICATED,
+      user,
+    }
+    const anonymous: AuthState = {
+      status: AUTH_STATE_STATUS.ANONYMOUS,
+      user: null,
+    }
+
+    expect(authenticated).toEqual({ status: "authenticated", user })
+    expect(anonymous).toEqual({ status: "anonymous", user: null })
+  })
+})

--- a/tests/unit/auth/supabase-server-adapter.test.ts
+++ b/tests/unit/auth/supabase-server-adapter.test.ts
@@ -1,0 +1,52 @@
+import { AuthSessionMissingError } from "@supabase/supabase-js"
+import { describe, expect, it } from "vitest"
+import { AUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { mapSupabaseUserResult } from "@/lib/auth/supabase-server-adapter"
+
+describe("Supabase server auth adapter", () => {
+  it("treats an empty successful response as an anonymous user", () => {
+    const result = mapSupabaseUserResult({
+      data: { user: null },
+      error: null,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it("treats a missing Supabase session as an anonymous user", () => {
+    const result = mapSupabaseUserResult({
+      data: { user: null },
+      error: new AuthSessionMissingError(),
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it("maps a real Supabase failure to the stable provider error", () => {
+    expect(() =>
+      mapSupabaseUserResult({
+        data: { user: null },
+        error: new Error("Supabase is unavailable"),
+      })
+    ).toThrow(expect.objectContaining({ code: AUTH_ERROR_CODE.PROVIDER_ERROR }))
+  })
+
+  it("maps an authenticated Supabase user to the controlled adapter shape", () => {
+    const result = mapSupabaseUserResult({
+      data: {
+        user: {
+          id: "user-1",
+          email: "driver@example.com",
+          user_metadata: { name: "Ada Driver" },
+        },
+      },
+      error: null,
+    })
+
+    expect(result).toEqual({
+      id: "user-1",
+      email: "driver@example.com",
+      userMetadata: { name: "Ada Driver" },
+    })
+  })
+})


### PR DESCRIPTION
## Qué cambia

- Añade contratos compartidos y discriminados para estado, resultados, errores y registro.
- Introduce una representación pública mínima `CurrentUser` con identificador, correo y nombre visible.
- Añade la API de servidor para obtener o exigir el usuario actual mediante `supabase.auth.getUser()`.
- Traduce ausencia de sesión a estado anónimo y fallos reales del proveedor a `provider_error`.
- Inicializa una nueva proyección React desde el servidor manteniendo el sistema de autenticación existente durante la migración.
- Añade pruebas unitarias y de integración con un adaptador controlado.

## Por qué

Establece la frontera de autenticación con autoridad en el servidor necesaria para migrar cada flujo de forma incremental, sin exponer sesiones, tokens, perfiles de base de datos ni clientes de Supabase al navegador.

## Impacto

No migra todavía consumidores ni elimina los providers legacy. La aplicación conserva el comportamiento actual mientras los siguientes tickets adoptan la nueva superficie pública.

## Validación

- `bun test` — 41 pruebas
- `bun type-check`
- `bun lint`
- `bun fmt:check`
- `bun run build`
- Revisión separada de spec y estándares sin hallazgos pendientes

Closes #41