### PR TITLE
Fix Dokploy preview validation

### DIFF
--- a/.github/scripts/dokploy-preview-check.mjs
+++ b/.github/scripts/dokploy-preview-check.mjs
@@ -1,0 +1,326 @@
+import { pathToFileURL } from "node:url"
+
+/* oxlint-disable no-console -- Console output is the CLI interface in GitHub Actions. */
+
+const DOKPLOY_BOT_LOGIN = "dokploy-chemicaldev-3[bot]"
+const DOKPLOY_HEADING = "### Dokploy Preview Deployment"
+const DOKPLOY_APP_ROW = /^\|\s*Keepel\s*\|/m
+const PREVIEW_HOST = /^preview-[a-z0-9-]+\.pr\.chemicaldev\.com$/
+const COMMENT_DISCOVERY_TIMEOUT_MS = 90_000
+const DEPLOYMENT_TIMEOUT_MS = 9 * 60_000
+const POLL_INTERVAL_MS = 10_000
+const HEALTH_CHECK_TIMEOUT_MS = 60_000
+const HEALTH_CHECK_INTERVAL_MS = 5_000
+const REQUEST_TIMEOUT_MS = 15_000
+const MAX_COMMENT_PAGES = 10
+const MAX_CONSECUTIVE_API_ERRORS = 3
+const HEALTHY_HTTP_STATUSES = new Set([200, 204, 301, 302, 307, 308])
+
+export function createPreviewState() {
+  return {
+    phase: "awaiting-building",
+    commentId: null,
+    buildingUpdatedAtMs: null,
+  }
+}
+
+export function findDokployComment(comments) {
+  return (
+    comments
+      .filter(
+        (comment) =>
+          comment?.user?.login === DOKPLOY_BOT_LOGIN &&
+          typeof comment.body === "string" &&
+          comment.body.includes(DOKPLOY_HEADING) &&
+          DOKPLOY_APP_ROW.test(comment.body)
+      )
+      .toSorted((left, right) => parseTimestamp(left.updated_at) - parseTimestamp(right.updated_at))
+      .at(-1) ?? null
+  )
+}
+
+export function extractPreviewUrl(body) {
+  if (typeof body !== "string") return null
+
+  const match = body.match(/\[Preview URL\]\((https?:\/\/[^\s)]+)\)/i)
+  if (!match) return null
+
+  try {
+    const url = new URL(match[1])
+    const isAllowedProtocol = url.protocol === "http:" || url.protocol === "https:"
+    const isAllowedHost = PREVIEW_HOST.test(url.hostname)
+    const hasDefaultAuthority = url.username === "" && url.password === "" && url.port === ""
+
+    return isAllowedProtocol && isAllowedHost && hasDefaultAuthority ? match[1] : null
+  } catch {
+    return null
+  }
+}
+
+export function evaluateDokployComment(state, comment, pullRequestUpdatedAt) {
+  const eventUpdatedAtMs = parseTimestamp(pullRequestUpdatedAt)
+  const commentCreatedAtMs = parseTimestamp(comment?.created_at)
+  const commentUpdatedAtMs = parseTimestamp(comment?.updated_at)
+
+  if (![eventUpdatedAtMs, commentCreatedAtMs, commentUpdatedAtMs].every(Number.isFinite)) {
+    return wait(state, "invalid-timestamp")
+  }
+
+  if (commentUpdatedAtMs < eventUpdatedAtMs) {
+    return wait(state, "stale-update")
+  }
+
+  const status = readDokployStatus(comment.body)
+
+  if (status === "building") {
+    return wait(
+      {
+        phase: "building",
+        commentId: comment.id,
+        buildingUpdatedAtMs: commentUpdatedAtMs,
+      },
+      "building"
+    )
+  }
+
+  if (status !== "done" && status !== "failed") {
+    return wait(state, "unknown-status")
+  }
+
+  const commentCreatedForEvent = commentCreatedAtMs >= eventUpdatedAtMs
+  const followsObservedBuilding =
+    state.phase === "building" && state.commentId === comment.id && commentUpdatedAtMs >= state.buildingUpdatedAtMs
+
+  if (!commentCreatedForEvent && !followsObservedBuilding) {
+    return wait(state, "awaiting-building")
+  }
+
+  if (status === "failed") {
+    return { kind: "failure", reason: "deployment-failed", state }
+  }
+
+  const previewUrl = extractPreviewUrl(comment.body)
+  if (!previewUrl) {
+    return { kind: "failure", reason: "invalid-preview-url", state }
+  }
+
+  return { kind: "ready", previewUrl, state }
+}
+
+function readDokployStatus(body) {
+  if (typeof body !== "string") return "unknown"
+  if (/\|\s*✅\s*Done\s*\|/i.test(body)) return "done"
+  if (/\|\s*❌\s*Failed\s*\|/i.test(body)) return "failed"
+  if (/\|\s*🔄\s*Building\s*\|/i.test(body)) return "building"
+  return "unknown"
+}
+
+function parseTimestamp(value) {
+  return typeof value === "string" ? Date.parse(value) : Number.NaN
+}
+
+function wait(state, reason) {
+  return { kind: "wait", reason, state }
+}
+
+async function run() {
+  const config = readConfig(process.env)
+  const startedAtMs = Date.now()
+  let state = createPreviewState()
+  let consecutiveApiErrors = 0
+  let attempt = 0
+
+  console.log(`Esperando la preview de Dokploy para la PR #${config.pullRequestNumber}...`)
+
+  while (Date.now() - startedAtMs < DEPLOYMENT_TIMEOUT_MS) {
+    attempt += 1
+
+    let comments
+    try {
+      comments = await fetchPullRequestComments(config)
+      consecutiveApiErrors = 0
+    } catch (error) {
+      consecutiveApiErrors += 1
+      console.warn(
+        `No se pudieron consultar los comentarios (${consecutiveApiErrors}/${MAX_CONSECUTIVE_API_ERRORS}): ${safeMessage(error)}`
+      )
+
+      if (consecutiveApiErrors >= MAX_CONSECUTIVE_API_ERRORS) {
+        throw new Error("La API de GitHub falló repetidamente al consultar los comentarios", {
+          cause: error,
+        })
+      }
+
+      await sleep(POLL_INTERVAL_MS)
+      continue
+    }
+
+    const comment = findDokployComment(comments)
+    if (!comment) {
+      if (Date.now() - startedAtMs >= COMMENT_DISCOVERY_TIMEOUT_MS) {
+        throw new Error("Dokploy no publicó su comentario dentro de 90 segundos")
+      }
+
+      console.log(`Intento ${attempt}: Dokploy todavía no ha publicado el comentario.`)
+      await sleep(POLL_INTERVAL_MS)
+      continue
+    }
+
+    const result = evaluateDokployComment(state, comment, config.pullRequestUpdatedAt)
+    state = result.state
+
+    if (result.kind === "failure") {
+      if (result.reason === "invalid-preview-url") {
+        throw new Error("Dokploy marcó el despliegue como Done, pero publicó una URL no permitida")
+      }
+
+      throw new Error("Dokploy marcó el despliegue como Failed")
+    }
+
+    if (result.kind === "ready") {
+      console.log(`Dokploy completó el despliegue: ${result.previewUrl}`)
+      await waitForHealthyPreview(result.previewUrl)
+      console.log("La preview está desplegada y responde correctamente.")
+      return
+    }
+
+    console.log(`Intento ${attempt}: ${describeWaitReason(result.reason)}`)
+    await sleep(POLL_INTERVAL_MS)
+  }
+
+  throw new Error("Dokploy no completó la preview dentro de 9 minutos")
+}
+
+function readConfig(environment) {
+  const githubToken = environment.GH_TOKEN
+  const repository = environment.REPO
+  const pullRequestNumber = environment.PR_NUMBER
+  const pullRequestUpdatedAt = environment.PR_UPDATED_AT
+
+  if (!githubToken) throw new Error("Falta GH_TOKEN")
+  if (!repository || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("REPO no tiene el formato owner/repository")
+  }
+  if (!pullRequestNumber || !/^\d+$/.test(pullRequestNumber)) {
+    throw new Error("PR_NUMBER no es válido")
+  }
+  if (!pullRequestUpdatedAt || !Number.isFinite(Date.parse(pullRequestUpdatedAt))) {
+    throw new Error("PR_UPDATED_AT no es válido")
+  }
+
+  return { githubToken, repository, pullRequestNumber, pullRequestUpdatedAt }
+}
+
+async function fetchPullRequestComments(config) {
+  const comments = []
+  let nextUrl = new URL(
+    `https://api.github.com/repos/${config.repository}/issues/${config.pullRequestNumber}/comments?per_page=100`
+  )
+
+  for (let page = 1; nextUrl; page += 1) {
+    if (page > MAX_COMMENT_PAGES) {
+      throw new Error(`La PR supera el límite de ${MAX_COMMENT_PAGES * 100} comentarios`)
+    }
+
+    const response = await fetchWithTimeout(nextUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${config.githubToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`GitHub respondió HTTP ${response.status}`)
+    }
+
+    const pageComments = await response.json()
+    if (!Array.isArray(pageComments)) {
+      throw new Error("GitHub devolvió una respuesta inesperada")
+    }
+
+    comments.push(...pageComments)
+    nextUrl = readNextPage(response.headers.get("link"))
+  }
+
+  return comments
+}
+
+function readNextPage(linkHeader) {
+  if (!linkHeader) return null
+
+  const nextLink = linkHeader
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => part.endsWith('rel="next"'))
+  const match = nextLink?.match(/^<([^>]+)>;/)
+  if (!match) return null
+
+  const nextUrl = new URL(match[1])
+  if (nextUrl.origin !== "https://api.github.com") {
+    throw new Error("GitHub devolvió una URL de paginación no permitida")
+  }
+
+  return nextUrl
+}
+
+async function waitForHealthyPreview(previewUrl) {
+  const deadlineMs = Date.now() + HEALTH_CHECK_TIMEOUT_MS
+  let attempt = 0
+
+  while (Date.now() < deadlineMs) {
+    attempt += 1
+
+    try {
+      const response = await fetchWithTimeout(previewUrl, { redirect: "manual" })
+      console.log(`Health check ${attempt}: HTTP ${response.status}`)
+
+      if (HEALTHY_HTTP_STATUSES.has(response.status)) return
+    } catch (error) {
+      console.log(`Health check ${attempt}: ${safeMessage(error)}`)
+    }
+
+    await sleep(HEALTH_CHECK_INTERVAL_MS)
+  }
+
+  throw new Error("La preview no respondió correctamente dentro de 60 segundos")
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function describeWaitReason(reason) {
+  const messages = {
+    "awaiting-building": "esperando una transición Building del despliegue actual.",
+    building: "Dokploy sigue construyendo.",
+    "invalid-timestamp": "el comentario contiene fechas no válidas.",
+    "stale-update": "el comentario todavía corresponde a un despliegue anterior.",
+    "unknown-status": "el comentario todavía no contiene un estado reconocido.",
+  }
+
+  return messages[reason] ?? "esperando una actualización de Dokploy."
+}
+
+function safeMessage(error) {
+  return error instanceof Error ? error.message.replace(/[\r\n]+/g, " ") : "Error desconocido"
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch((error) => {
+    const message = safeMessage(error).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")
+    console.error(`::error::${message}`)
+    process.exitCode = 1
+  })
+}

--- a/.github/workflows/dokploy-preview-check.yml
+++ b/.github/workflows/dokploy-preview-check.yml
@@ -5,71 +5,28 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: read
   pull-requests: read
+
+concurrency:
+  group: dokploy-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check-preview-ready:
     name: Validate Preview URL
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
-      - name: Wait for Build Status and Verify URL
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Wait for Dokploy preview and verify availability
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        run: |
-          echo "Verificando el estado del despliegue en los comentarios de la PR #$PR_NUMBER..."
-
-          PREVIEW_URL=""
-          IS_DONE=false
-
-          # Paso 1: Esperar a que el comentario diga "Done" o "Success" (máximo 7.5 minutos)
-          for i in {1..30}; do
-            # Obtenemos el cuerpo del último comentario que contenga nuestro dominio
-            COMMENT_BODY=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments" | \
-              jq -r '[.[] | select(.body | contains("dev-env.chemicaldev.com"))] | last | .body')
-            
-            if [ -z "$COMMENT_BODY" ] || [ "$COMMENT_BODY" == "null" ]; then
-              echo "Comentario de Dokploy no encontrado aún. Intento $i..."
-            else
-              # Comprobamos las palabras clave del estado en el texto (ignorando mayúsculas/minúsculas)
-              if echo "$COMMENT_BODY" | grep -iq "Building"; then
-                echo "Dokploy sigue construyendo el nuevo commit (Status: Building). Esperando..."
-              
-              elif echo "$COMMENT_BODY" | grep -iqE "Done|Success|Deployed|Ready"; then
-                echo "¡La build ha terminado! (Status: Done)"
-                IS_DONE=true
-                
-                # Extraemos la URL del texto
-                PREVIEW_URL=$(echo "$COMMENT_BODY" | grep -oE 'https://preview-[a-zA-Z0-9-]+\.dev-env\.chemicaldev\.com' | head -n 1)
-                break
-              
-              else
-                echo "Estado desconocido o preparándose. Esperando a que cambie a Done..."
-              fi
-            fi
-            sleep 15
-          done
-
-          if [ "$IS_DONE" = false ]; then
-            echo "Error: La build no alcanzó el estado 'Done' en el tiempo esperado."
-            exit 1
-          fi
-
-          echo "Comprobando disponibilidad real de la web: $PREVIEW_URL"
-
-          # Paso 2: Ahora que sabemos que la build terminó, aseguramos que el contenedor responde 200
-          for i in {1..10}; do
-            STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "$PREVIEW_URL")
-            echo "Intento de conexión $i: HTTP $STATUS"
-            
-            if [[ "$STATUS" =~ ^(200|301|302)$ ]]; then
-              echo "¡La nueva preview está desplegada y respondiendo correctamente!"
-              exit 0
-            fi
-            sleep 10
-          done
-
-          echo "Error: La URL no devolvió 200 OK a pesar de que Dokploy marcó la build como Done."
-          exit 1
+          PR_UPDATED_AT: ${{ github.event.pull_request.updated_at }}
+        run: node .github/scripts/dokploy-preview-check.mjs

--- a/tests/unit/ci/dokploy-preview-check.test.ts
+++ b/tests/unit/ci/dokploy-preview-check.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createPreviewState,
+  evaluateDokployComment,
+  extractPreviewUrl,
+  findDokployComment,
+} from "../../../.github/scripts/dokploy-preview-check.mjs"
+
+const PR_UPDATED_AT = "2026-07-18T09:22:06.000Z"
+const BUILDING_AT = "2026-07-18T09:22:11.000Z"
+const DONE_AT = "2026-07-18T09:24:37.000Z"
+const PREVIEW_URL = "http://preview-keepel-ym4zdo-jwqaqh.pr.chemicaldev.com"
+
+function dokployBody(status: "Building" | "Done" | "Failed", url = PREVIEW_URL) {
+  const icon = status === "Building" ? "🔄" : status === "Done" ? "✅" : "❌"
+
+  return `### Dokploy Preview Deployment
+
+| Name | Status | Preview | Updated (UTC) |
+| --- | --- | --- | --- |
+| Keepel | ${icon} ${status} | [Preview URL](${url}) | ${DONE_AT} |`
+}
+
+function comment({
+  id = 5010737589,
+  login = "dokploy-chemicaldev-3[bot]",
+  status = "Building",
+  createdAt = BUILDING_AT,
+  updatedAt = BUILDING_AT,
+}: {
+  id?: number
+  login?: string
+  status?: "Building" | "Done" | "Failed"
+  createdAt?: string
+  updatedAt?: string
+} = {}) {
+  return {
+    id,
+    body: dokployBody(status),
+    created_at: createdAt,
+    updated_at: updatedAt,
+    user: { login },
+  }
+}
+
+describe("findDokployComment", () => {
+  it("ignores lookalike comments and returns the latest comment from the Dokploy bot", () => {
+    const spoofed = comment({ id: 1, login: "contributor", status: "Done", updatedAt: DONE_AT })
+    const actual = comment({ id: 2, status: "Building" })
+
+    expect(findDokployComment([spoofed, actual])).toEqual(actual)
+  })
+})
+
+describe("evaluateDokployComment", () => {
+  it("accepts Done only after observing a fresh Building transition on an existing comment", () => {
+    const initialState = createPreviewState()
+    const building = comment({ createdAt: "2026-06-12T18:37:37.000Z" })
+
+    const buildingResult = evaluateDokployComment(initialState, building, PR_UPDATED_AT)
+
+    expect(buildingResult).toMatchObject({ kind: "wait", reason: "building" })
+
+    const done = comment({
+      createdAt: building.created_at,
+      status: "Done",
+      updatedAt: DONE_AT,
+    })
+    const doneResult = evaluateDokployComment(buildingResult.state, done, PR_UPDATED_AT)
+
+    expect(doneResult).toMatchObject({ kind: "ready", previewUrl: PREVIEW_URL })
+  })
+
+  it("accepts a terminal state immediately when Dokploy created the comment for this event", () => {
+    const freshDone = comment({ status: "Done", createdAt: BUILDING_AT, updatedAt: DONE_AT })
+
+    expect(evaluateDokployComment(createPreviewState(), freshDone, PR_UPDATED_AT)).toMatchObject({
+      kind: "ready",
+      previewUrl: PREVIEW_URL,
+    })
+  })
+
+  it("ignores a stale Done from a previous deployment", () => {
+    const staleDone = comment({
+      status: "Done",
+      createdAt: "2026-06-12T18:37:37.000Z",
+      updatedAt: "2026-07-18T09:21:59.000Z",
+    })
+
+    expect(evaluateDokployComment(createPreviewState(), staleDone, PR_UPDATED_AT)).toMatchObject({
+      kind: "wait",
+      reason: "stale-update",
+    })
+  })
+
+  it("does not accept a newer Done on an old comment without first seeing Building", () => {
+    const overlappingDone = comment({
+      status: "Done",
+      createdAt: "2026-06-12T18:37:37.000Z",
+      updatedAt: DONE_AT,
+    })
+
+    expect(evaluateDokployComment(createPreviewState(), overlappingDone, PR_UPDATED_AT)).toMatchObject({
+      kind: "wait",
+      reason: "awaiting-building",
+    })
+  })
+
+  it("fails immediately when the observed deployment changes from Building to Failed", () => {
+    const buildingResult = evaluateDokployComment(
+      createPreviewState(),
+      comment({ createdAt: "2026-06-12T18:37:37.000Z" }),
+      PR_UPDATED_AT
+    )
+    const failed = comment({
+      createdAt: "2026-06-12T18:37:37.000Z",
+      status: "Failed",
+      updatedAt: DONE_AT,
+    })
+
+    expect(evaluateDokployComment(buildingResult.state, failed, PR_UPDATED_AT)).toMatchObject({
+      kind: "failure",
+      reason: "deployment-failed",
+    })
+  })
+})
+
+describe("extractPreviewUrl", () => {
+  it("accepts the current Dokploy preview domain over HTTP", () => {
+    expect(extractPreviewUrl(dokployBody("Done"))).toBe(PREVIEW_URL)
+  })
+
+  it("rejects URLs outside the configured preview hostname", () => {
+    expect(extractPreviewUrl(dokployBody("Done", "https://example.com/preview"))).toBeNull()
+  })
+})


### PR DESCRIPTION
## What changed

- Replace the brittle inline shell polling with a tested Node.js checker.
- Identify the exact Dokploy bot comment, paginate comments, and validate the current preview hostname.
- Model fresh deployment transitions so stale terminal statuses cannot satisfy a new run.
- Add bounded API retries, comment discovery timeout, preview health checks, and fail-fast handling.
- Cancel superseded workflow runs and pin the checkout action by commit SHA.

## Why

The workflow searched for the obsolete `dev-env.chemicaldev.com` hostname while Dokploy now publishes previews under `preview-*.pr.chemicaldev.com`. Valid Dokploy comments were therefore ignored until the job timed out. The previous implementation also lacked pagination and could accept stale status text.

## Impact

PR preview validation now follows the current Dokploy comment format, cancels stale runs, reports integration failures earlier, and verifies that the resulting preview is reachable without disabling TLS validation.

## Validation

- `bun test` — 49 tests passed
- `bun type-check`
- `bun lint`
- `bunx oxfmt --check .github/workflows/dokploy-preview-check.yml .github/scripts/dokploy-preview-check.mjs tests/unit/ci/dokploy-preview-check.test.ts`
- `node --check .github/scripts/dokploy-preview-check.mjs`
- `git diff --cached --check`
