### PR TITLE
Migrate signup to the server auth boundary

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -3,22 +3,13 @@
 /* eslint-disable no-console -- Server actions log unexpected auth failures until centralized observability is added. */
 
 import { headers } from "next/headers"
-import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
 import { createPasswordLoginCommand, type PasswordLoginResult } from "@/lib/auth/password-login"
+import { createSignupCommand } from "@/lib/auth/signup"
 import { createSupabasePasswordLoginAuthAdapter } from "@/lib/auth/supabase-password-login-adapter"
+import { createSupabaseSignupAuthAdapter } from "@/lib/auth/supabase-signup-adapter"
 import { loginRateLimiter, signupRateLimiter } from "@/lib/ratelimit"
 import { createClient } from "@/lib/supabase/server"
-
-interface SignupResult {
-  success: boolean
-  error?: string
-  rateLimit?: {
-    remaining: number
-    limit: number
-    reset: number
-  }
-  redirectTo?: string
-}
 
 const passwordLogin = createPasswordLoginCommand({
   authAdapter: createSupabasePasswordLoginAuthAdapter(createClient),
@@ -30,6 +21,21 @@ const passwordLogin = createPasswordLoginCommand({
       ])
 
       return emailLimit.success && ipLimit.success
+    },
+  },
+})
+
+const signup = createSignupCommand({
+  authAdapter: createSupabaseSignupAuthAdapter(createClient),
+  rateLimitAdapter: {
+    async isAllowed({ email, clientIp }) {
+      const ipLimit = await signupRateLimiter.limit(`signup_ip_${clientIp}`)
+
+      if (!ipLimit.success) {
+        return false
+      }
+
+      return (await signupRateLimiter.limit(`signup_email_${email}`)).success
     },
   },
 })
@@ -63,83 +69,27 @@ export async function loginAction(
   }
 }
 
-export async function signupAction(email: string, password: string, fullName: string): Promise<SignupResult> {
+export async function signupAction(_previousResult: SignUpResult | null, formData: FormData): Promise<SignUpResult> {
   try {
-    // Obtener IP del usuario
     const headersList = await headers()
-    const ip = headersList.get("x-forwarded-for")?.split(",")[0] ?? headersList.get("x-real-ip") ?? "127.0.0.1"
 
-    const sanitizedEmail = email.toLowerCase().trim()
-
-    // Verificar rate limit por IP
-    const ipLimit = await signupRateLimiter.limit(`signup_ip_${ip}`)
-
-    if (!ipLimit.success) {
-      return {
-        success: false,
-        error: "Demasiados intentos de registro desde esta IP. Intenta más tarde.",
-        rateLimit: {
-          remaining: 0,
-          limit: ipLimit.limit,
-          reset: ipLimit.reset,
-        },
-      }
-    }
-
-    // Verificar rate limit por email
-    const emailLimit = await signupRateLimiter.limit(`signup_email_${sanitizedEmail}`)
-
-    if (!emailLimit.success) {
-      return {
-        success: false,
-        error: "Demasiados intentos de registro para este email. Por seguridad, espera un momento.",
-        rateLimit: {
-          remaining: 0,
-          limit: emailLimit.limit,
-          reset: emailLimit.reset,
-        },
-      }
-    }
-
-    // Intentar registro con Supabase
-    const supabase = await createClient()
-    const redirectUrl =
-      process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL ||
-      process.env.NEXT_PUBLIC_SUPABASE_REDIRECT_URL ||
-      "http://localhost:3000/"
-
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: redirectUrl,
-        data: {
-          full_name: fullName,
-        },
-      },
+    return await signup({
+      email: formData.get("email"),
+      password: formData.get("password"),
+      confirmPassword: formData.get("confirmPassword"),
+      fullName: formData.get("fullName"),
+      clientIp: readClientIp(headersList),
+      emailRedirectTo:
+        process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL ||
+        process.env.NEXT_PUBLIC_SUPABASE_REDIRECT_URL ||
+        "http://localhost:3000/",
     })
-
-    if (error) {
-      return {
-        success: false,
-        error: error.message,
-        rateLimit: {
-          remaining: emailLimit.remaining,
-          limit: emailLimit.limit,
-          reset: emailLimit.reset,
-        },
-      }
-    }
-
-    return {
-      success: true,
-      redirectTo: "/auth/signup-success",
-    }
   } catch (error) {
-    console.error("Error en signupAction:", error)
+    console.error("Unexpected signup action failure:", error)
+
     return {
-      success: false,
-      error: error instanceof Error ? error.message : "Error desconocido",
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.UNEXPECTED },
     }
   }
 }

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -3,8 +3,15 @@
 /* eslint-disable no-console -- Server actions log unexpected auth failures until centralized observability is added. */
 
 import { headers } from "next/headers"
-import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
+import {
+  AUTH_COMMAND_STATUS,
+  AUTH_ERROR_CODE,
+  SIGN_UP_RATE_LIMIT_SCOPE,
+  SIGN_UP_STATUS,
+  type SignUpResult,
+} from "@/lib/auth/contracts"
 import { createPasswordLoginCommand, type PasswordLoginResult } from "@/lib/auth/password-login"
+import { getCurrentUser } from "@/lib/auth/server"
 import { createSignupCommand } from "@/lib/auth/signup"
 import { createSupabasePasswordLoginAuthAdapter } from "@/lib/auth/supabase-password-login-adapter"
 import { createSupabaseSignupAuthAdapter } from "@/lib/auth/supabase-signup-adapter"
@@ -32,10 +39,26 @@ const signup = createSignupCommand({
       const ipLimit = await signupRateLimiter.limit(`signup_ip_${clientIp}`)
 
       if (!ipLimit.success) {
-        return false
+        return {
+          allowed: false,
+          scope: SIGN_UP_RATE_LIMIT_SCOPE.IP,
+          remaining: ipLimit.remaining,
+          limit: ipLimit.limit,
+          reset: ipLimit.reset,
+        }
       }
 
-      return (await signupRateLimiter.limit(`signup_email_${email}`)).success
+      const emailLimit = await signupRateLimiter.limit(`signup_email_${email}`)
+
+      return emailLimit.success
+        ? { allowed: true }
+        : {
+            allowed: false,
+            scope: SIGN_UP_RATE_LIMIT_SCOPE.EMAIL,
+            remaining: emailLimit.remaining,
+            limit: emailLimit.limit,
+            reset: emailLimit.reset,
+          }
     },
   },
 })
@@ -71,6 +94,12 @@ export async function loginAction(
 
 export async function signupAction(_previousResult: SignUpResult | null, formData: FormData): Promise<SignUpResult> {
   try {
+    const currentUser = await getCurrentUser()
+
+    if (currentUser) {
+      return { status: SIGN_UP_STATUS.AUTHENTICATED, user: currentUser }
+    }
+
     const headersList = await headers()
 
     return await signup({

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,90 +1,12 @@
 "use client"
 
-/* eslint-disable eslint/no-shadow -- Local form error state is intentionally named `error` for UI clarity. */
-
-import type React from "react"
-import { Layout } from "../../../components/layout/Layout"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { GoogleSignInButton } from "@/components/auth/google-signin-button"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useState } from "react"
-import { useSupabase } from "@/hooks/useSupabase"
-import { signupAction } from "../actions"
-import { sanitizeInternalRedirect } from "@/lib/auth/redirects"
+import { GoogleSignInButton } from "@/components/auth/google-signin-button"
+import { SignupForm } from "@/components/auth/signup-form"
+import { Layout } from "@/components/layout/Layout"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 
 export default function SignUpPage() {
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-  const [fullName, setFullName] = useState("")
-  const [error, setError] = useState<string | null>(null)
-  const [rateLimitInfo, setRateLimitInfo] = useState<{
-    remaining: number
-    limit: number
-    reset: number
-  } | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const router = useRouter()
-
-  // Crear una sola instancia del cliente de Supabase para toda la página
-  const supabase = useSupabase()
-
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setIsLoading(true)
-    setError(null)
-    setRateLimitInfo(null)
-
-    if (password !== confirmPassword) {
-      setError("Las contraseñas no coinciden")
-      setIsLoading(false)
-      return
-    }
-
-    if (password.length < 6) {
-      setError("La contraseña debe tener al menos 6 caracteres")
-      setIsLoading(false)
-      return
-    }
-
-    try {
-      // Llamar al Server Action
-      const result = await signupAction(email, password, fullName)
-
-      if (!result.success) {
-        // Si hay información de rate limit, actualizarla
-        if (result.rateLimit) {
-          setRateLimitInfo(result.rateLimit)
-
-          if (result.rateLimit.remaining > 0) {
-            setError(`${result.error}. Te quedan ${result.rateLimit.remaining} de ${result.rateLimit.limit} intentos.`)
-          } else {
-            const hoursLeft = Math.ceil((result.rateLimit.reset - Date.now()) / 1000 / 60 / 60)
-            setError(`${result.error}. Podrás intentar de nuevo en ${hoursLeft} hora(s).`)
-          }
-        } else {
-          setError(result.error || "Error al crear la cuenta")
-        }
-        return
-      }
-
-      // Redirigir a la página de éxito
-      router.push(sanitizeInternalRedirect(result.redirectTo ?? "/auth/signup-success"))
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        setError(error.message)
-      } else {
-        setError("Ocurrió un error desconocido")
-      }
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
   return (
     <Layout showHeader={true}>
       <div className="flex min-h-screen items-center justify-center p-6">
@@ -98,9 +20,7 @@ export default function SignUpPage() {
             </CardHeader>
             <CardContent>
               <div className="flex justify-center">
-                <GoogleSignInButton className="cursor-pointer" supabaseClient={supabase}>
-                  Crear cuenta con Google
-                </GoogleSignInButton>
+                <GoogleSignInButton className="cursor-pointer">Crear cuenta con Google</GoogleSignInButton>
               </div>
               <div className="relative my-6">
                 <div className="absolute inset-0 flex items-center">
@@ -111,90 +31,14 @@ export default function SignUpPage() {
                 </div>
               </div>
 
-              <form onSubmit={handleSignUp}>
-                <div className="flex flex-col gap-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="fullName" className="text-foreground">
-                      Nombre Completo
-                    </Label>
-                    <Input
-                      id="fullName"
-                      type="text"
-                      placeholder="Tu nombre completo"
-                      required
-                      value={fullName}
-                      onChange={(e) => setFullName(e.target.value)}
-                      className="bg-input border-border"
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="email" className="text-foreground">
-                      Email
-                    </Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      placeholder="tu@email.com"
-                      required
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      className="bg-input border-border"
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="password" className="text-foreground">
-                      Contraseña
-                    </Label>
-                    <Input
-                      id="password"
-                      type="password"
-                      placeholder="Mínimo 6 caracteres"
-                      required
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      className="bg-input border-border"
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="confirmPassword" className="text-foreground">
-                      Confirmar Contraseña
-                    </Label>
-                    <Input
-                      id="confirmPassword"
-                      type="password"
-                      placeholder="Repite tu contraseña"
-                      required
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      className="bg-input border-border"
-                    />
-                  </div>
-                  {error && (
-                    <div className="text-destructive-foreground bg-destructive/10 border-destructive/20 rounded-md border p-3 text-sm">
-                      <p>{error}</p>
-                      {rateLimitInfo && rateLimitInfo.remaining === 0 && (
-                        <p className="mt-2 text-xs">
-                          Has alcanzado el límite de intentos de registro. Podrás intentar de nuevo en{" "}
-                          {Math.ceil((rateLimitInfo.reset - Date.now()) / 1000 / 60 / 60)} hora(s).
-                        </p>
-                      )}
-                    </div>
-                  )}
-                  <Button
-                    type="submit"
-                    className="bg-primary hover:bg-primary/90 text-primary-foreground w-full cursor-pointer"
-                    disabled={isLoading}
-                  >
-                    {isLoading ? "Creando cuenta..." : "Crear Cuenta"}
-                  </Button>
-                </div>
-                <div className="text-muted-foreground mt-4 text-center text-sm">
-                  ¿Ya tienes una cuenta?{" "}
-                  <Link href="/auth/login" className="text-primary hover:text-primary/80 underline underline-offset-4">
-                    Inicia sesión
-                  </Link>
-                </div>
-              </form>
+              <SignupForm />
+
+              <div className="text-muted-foreground mt-4 text-center text-sm">
+                ¿Ya tienes una cuenta?{" "}
+                <Link href="/auth/login" className="text-primary hover:text-primary/80 underline underline-offset-4">
+                  Inicia sesión
+                </Link>
+              </div>
             </CardContent>
           </Card>
         </div>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import Link from "next/link"
 import { GoogleSignInButton } from "@/components/auth/google-signin-button"
 import { SignupForm } from "@/components/auth/signup-form"

--- a/components/auth/google-signin-button.tsx
+++ b/components/auth/google-signin-button.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 /* eslint-disable no-console -- OAuth failures are logged locally until centralized observability is added. */
 
 import { useState } from "react"

--- a/components/auth/signup-feedback.tsx
+++ b/components/auth/signup-feedback.tsx
@@ -1,9 +1,16 @@
-import { AUTH_ERROR_CODE, type AuthError } from "@/lib/auth/contracts"
+import { AUTH_ERROR_CODE, SIGN_UP_RATE_LIMIT_SCOPE, type SignUpError } from "@/lib/auth/contracts"
 
-function getSignupErrorMessage(error: AuthError) {
+function getSignupErrorMessage(error: SignUpError) {
   switch (error.code) {
-    case AUTH_ERROR_CODE.RATE_LIMITED:
-      return "Demasiados intentos de registro. Espera un momento antes de volver a intentarlo."
+    case AUTH_ERROR_CODE.RATE_LIMITED: {
+      const reason =
+        error.scope === SIGN_UP_RATE_LIMIT_SCOPE.IP
+          ? "Demasiados intentos de registro desde esta IP. Intenta más tarde."
+          : "Demasiados intentos de registro para este email. Por seguridad, espera un momento."
+      const hoursLeft = Math.max(1, Math.ceil((error.reset - Date.now()) / 1_000 / 60 / 60))
+
+      return `${reason} Podrás intentar de nuevo en ${hoursLeft} hora(s).`
+    }
     case AUTH_ERROR_CODE.VALIDATION_FAILED:
       return "Revisa el nombre, el email y las contraseñas e inténtalo de nuevo."
     case AUTH_ERROR_CODE.INVALID_CREDENTIALS:
@@ -18,7 +25,7 @@ function getSignupErrorMessage(error: AuthError) {
 }
 
 interface SignupFeedbackProps {
-  error: AuthError | null
+  error: SignUpError | null
 }
 
 export function SignupFeedback({ error }: SignupFeedbackProps) {

--- a/components/auth/signup-feedback.tsx
+++ b/components/auth/signup-feedback.tsx
@@ -1,0 +1,38 @@
+import { AUTH_ERROR_CODE, type AuthError } from "@/lib/auth/contracts"
+
+function getSignupErrorMessage(error: AuthError) {
+  switch (error.code) {
+    case AUTH_ERROR_CODE.RATE_LIMITED:
+      return "Demasiados intentos de registro. Espera un momento antes de volver a intentarlo."
+    case AUTH_ERROR_CODE.VALIDATION_FAILED:
+      return "Revisa el nombre, el email y las contraseñas e inténtalo de nuevo."
+    case AUTH_ERROR_CODE.INVALID_CREDENTIALS:
+    case AUTH_ERROR_CODE.PROVIDER_ERROR:
+      return "No pudimos crear la cuenta. Inténtalo de nuevo."
+    case AUTH_ERROR_CODE.UNEXPECTED:
+      return "Ocurrió un error inesperado. Inténtalo de nuevo."
+    case AUTH_ERROR_CODE.AUTHENTICATION_REQUIRED:
+    case AUTH_ERROR_CODE.SESSION_EXPIRED:
+      return "Tu sesión no está disponible. Vuelve a intentarlo."
+  }
+}
+
+interface SignupFeedbackProps {
+  error: AuthError | null
+}
+
+export function SignupFeedback({ error }: SignupFeedbackProps) {
+  if (!error) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="text-destructive bg-destructive/10 border-destructive/20 rounded-md border p-3 text-sm"
+    >
+      {getSignupErrorMessage(error)}
+    </div>
+  )
+}

--- a/components/auth/signup-form-action.ts
+++ b/components/auth/signup-form-action.ts
@@ -1,0 +1,45 @@
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
+import { parseSignupInput } from "@/lib/auth/signup-validation"
+
+interface SignupFormActionDependencies {
+  signupAction(previousResult: SignUpResult | null, formData: FormData): Promise<SignUpResult>
+  onAuthenticated(destination: string): void
+  onConfirmationRequired(destination: string): void
+}
+
+export async function runSignupFormAction(
+  previousResult: SignUpResult | null,
+  formData: FormData,
+  dependencies: SignupFormActionDependencies
+): Promise<SignUpResult> {
+  const signupInput = parseSignupInput({
+    email: formData.get("email"),
+    password: formData.get("password"),
+    confirmPassword: formData.get("confirmPassword"),
+    fullName: formData.get("fullName"),
+  })
+
+  if (!signupInput.success) {
+    return {
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.VALIDATION_FAILED },
+    }
+  }
+
+  formData.set("email", signupInput.data.email)
+  formData.set("fullName", signupInput.data.fullName)
+  const result = await dependencies.signupAction(previousResult, formData)
+
+  switch (result.status) {
+    case SIGN_UP_STATUS.AUTHENTICATED:
+      dependencies.onAuthenticated("/")
+      break
+    case SIGN_UP_STATUS.CONFIRMATION_REQUIRED:
+      dependencies.onConfirmationRequired("/auth/signup-success")
+      break
+    case SIGN_UP_STATUS.ERROR:
+      break
+  }
+
+  return result
+}

--- a/components/auth/signup-form.tsx
+++ b/components/auth/signup-form.tsx
@@ -6,8 +6,8 @@ import { signupAction } from "@/app/auth/actions"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
 import { SignupFeedback } from "./signup-feedback"
+import { SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
 import { runSignupFormAction } from "./signup-form-action"
 
 export function SignupForm() {
@@ -29,7 +29,7 @@ export function SignupForm() {
   const error = result?.status === SIGN_UP_STATUS.ERROR ? result.error : null
 
   return (
-    <form action={formAction} aria-busy={isPending}>
+    <form action={formAction} aria-busy={isPending} noValidate>
       <div className="flex flex-col gap-4">
         <div className="grid gap-2">
           <Label htmlFor="fullName" className="text-foreground">
@@ -71,7 +71,6 @@ export function SignupForm() {
             type="password"
             autoComplete="new-password"
             placeholder="Mínimo 6 caracteres"
-            minLength={6}
             required
             disabled={isPending}
             className="bg-input border-border"
@@ -87,7 +86,6 @@ export function SignupForm() {
             type="password"
             autoComplete="new-password"
             placeholder="Repite tu contraseña"
-            minLength={6}
             required
             disabled={isPending}
             className="bg-input border-border"

--- a/components/auth/signup-form.tsx
+++ b/components/auth/signup-form.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useActionState } from "react"
+import { useRouter } from "next/navigation"
+import { signupAction } from "@/app/auth/actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
+import { SignupFeedback } from "./signup-feedback"
+import { runSignupFormAction } from "./signup-form-action"
+
+export function SignupForm() {
+  const router = useRouter()
+  const [result, formAction, isPending] = useActionState(
+    (previousResult: SignUpResult | null, formData: FormData) =>
+      runSignupFormAction(previousResult, formData, {
+        signupAction,
+        onAuthenticated(destination) {
+          router.replace(destination)
+          router.refresh()
+        },
+        onConfirmationRequired(destination) {
+          router.replace(destination)
+        },
+      }),
+    null
+  )
+  const error = result?.status === SIGN_UP_STATUS.ERROR ? result.error : null
+
+  return (
+    <form action={formAction} aria-busy={isPending}>
+      <div className="flex flex-col gap-4">
+        <div className="grid gap-2">
+          <Label htmlFor="fullName" className="text-foreground">
+            Nombre Completo
+          </Label>
+          <Input
+            id="fullName"
+            name="fullName"
+            type="text"
+            autoComplete="name"
+            placeholder="Tu nombre completo"
+            required
+            disabled={isPending}
+            className="bg-input border-border"
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="email" className="text-foreground">
+            Email
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            placeholder="tu@email.com"
+            required
+            disabled={isPending}
+            className="bg-input border-border"
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="password" className="text-foreground">
+            Contraseña
+          </Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            placeholder="Mínimo 6 caracteres"
+            minLength={6}
+            required
+            disabled={isPending}
+            className="bg-input border-border"
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="confirmPassword" className="text-foreground">
+            Confirmar Contraseña
+          </Label>
+          <Input
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            placeholder="Repite tu contraseña"
+            minLength={6}
+            required
+            disabled={isPending}
+            className="bg-input border-border"
+          />
+        </div>
+
+        <SignupFeedback error={error} />
+
+        <Button type="submit" className="w-full" disabled={isPending}>
+          {isPending ? "Creando cuenta..." : "Crear Cuenta"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/lib/auth/contracts.ts
+++ b/lib/auth/contracts.ts
@@ -24,6 +24,11 @@ export const SIGN_UP_STATUS = {
   ERROR: "error",
 } as const
 
+export const SIGN_UP_RATE_LIMIT_SCOPE = {
+  IP: "ip",
+  EMAIL: "email",
+} as const
+
 type ValueOf<T> = T[keyof T]
 
 declare const userIdBrand: unique symbol
@@ -31,6 +36,8 @@ declare const userIdBrand: unique symbol
 export type UserId = string & { readonly [userIdBrand]: "UserId" }
 
 export type AuthErrorCode = ValueOf<typeof AUTH_ERROR_CODE>
+
+export type SignUpRateLimitScope = ValueOf<typeof SIGN_UP_RATE_LIMIT_SCOPE>
 
 export type AuthError = {
   [Code in AuthErrorCode]: { code: Code }
@@ -62,6 +69,16 @@ export type AuthCommandResult<SuccessData = undefined> =
       error: AuthError
     }
 
+export type SignUpError =
+  | Exclude<AuthError, { code: typeof AUTH_ERROR_CODE.RATE_LIMITED }>
+  | {
+      code: typeof AUTH_ERROR_CODE.RATE_LIMITED
+      scope: SignUpRateLimitScope
+      remaining: number
+      limit: number
+      reset: number
+    }
+
 export type SignUpResult =
   | {
       status: typeof SIGN_UP_STATUS.AUTHENTICATED
@@ -72,5 +89,5 @@ export type SignUpResult =
     }
   | {
       status: typeof SIGN_UP_STATUS.ERROR
-      error: AuthError
+      error: SignUpError
     }

--- a/lib/auth/server-boundary.ts
+++ b/lib/auth/server-boundary.ts
@@ -68,7 +68,7 @@ function parseAdapterUser(value: unknown): AuthServerAdapterUser | null {
   }
 }
 
-function projectCurrentUser(user: AuthServerAdapterUser): CurrentUser {
+export function projectCurrentUser(user: AuthServerAdapterUser): CurrentUser {
   const email = user.email ?? null
 
   return {

--- a/lib/auth/signup-validation.ts
+++ b/lib/auth/signup-validation.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+
+const SIGNUP_INPUT_SCHEMA = z
+  .object({
+    email: z.string().trim().toLowerCase().email(),
+    password: z.string().min(6),
+    confirmPassword: z.string(),
+    fullName: z.string().trim().min(1),
+  })
+  .refine(({ password, confirmPassword }) => password === confirmPassword, {
+    path: ["confirmPassword"],
+  })
+
+export function parseSignupInput(input: {
+  email: unknown
+  password: unknown
+  confirmPassword: unknown
+  fullName: unknown
+}) {
+  return SIGNUP_INPUT_SCHEMA.safeParse(input)
+}

--- a/lib/auth/signup.ts
+++ b/lib/auth/signup.ts
@@ -1,4 +1,4 @@
-import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpResult } from "./contracts"
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpRateLimitScope, type SignUpResult } from "./contracts"
 import { parseSignupInput } from "./signup-validation"
 
 export interface SignupInput {
@@ -15,7 +15,16 @@ export interface SignupAuthAdapter {
 }
 
 export interface SignupRateLimitAdapter {
-  isAllowed(input: { email: string; clientIp: string }): Promise<boolean>
+  isAllowed(input: { email: string; clientIp: string }): Promise<
+    | { allowed: true }
+    | {
+        allowed: false
+        scope: SignUpRateLimitScope
+        remaining: number
+        limit: number
+        reset: number
+      }
+  >
 }
 
 interface SignupDependencies {
@@ -37,10 +46,18 @@ export function createSignupCommand({ authAdapter, rateLimitAdapter }: SignupDep
     const { email, password, fullName } = signupInput.data
 
     try {
-      if (!(await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp }))) {
+      const rateLimit = await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp })
+
+      if (!rateLimit.allowed) {
         return {
           status: SIGN_UP_STATUS.ERROR,
-          error: { code: AUTH_ERROR_CODE.RATE_LIMITED },
+          error: {
+            code: AUTH_ERROR_CODE.RATE_LIMITED,
+            scope: rateLimit.scope,
+            remaining: rateLimit.remaining,
+            limit: rateLimit.limit,
+            reset: rateLimit.reset,
+          },
         }
       }
 

--- a/lib/auth/signup.ts
+++ b/lib/auth/signup.ts
@@ -1,0 +1,60 @@
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpResult } from "./contracts"
+import { parseSignupInput } from "./signup-validation"
+
+export interface SignupInput {
+  email: unknown
+  password: unknown
+  confirmPassword: unknown
+  fullName: unknown
+  clientIp: string
+  emailRedirectTo: string
+}
+
+export interface SignupAuthAdapter {
+  signUp(input: { email: string; password: string; fullName: string; emailRedirectTo: string }): Promise<SignUpResult>
+}
+
+export interface SignupRateLimitAdapter {
+  isAllowed(input: { email: string; clientIp: string }): Promise<boolean>
+}
+
+interface SignupDependencies {
+  authAdapter: SignupAuthAdapter
+  rateLimitAdapter: SignupRateLimitAdapter
+}
+
+export function createSignupCommand({ authAdapter, rateLimitAdapter }: SignupDependencies) {
+  return async function signup(input: SignupInput): Promise<SignUpResult> {
+    const signupInput = parseSignupInput(input)
+
+    if (!signupInput.success) {
+      return {
+        status: SIGN_UP_STATUS.ERROR,
+        error: { code: AUTH_ERROR_CODE.VALIDATION_FAILED },
+      }
+    }
+
+    const { email, password, fullName } = signupInput.data
+
+    try {
+      if (!(await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp }))) {
+        return {
+          status: SIGN_UP_STATUS.ERROR,
+          error: { code: AUTH_ERROR_CODE.RATE_LIMITED },
+        }
+      }
+
+      return await authAdapter.signUp({
+        email,
+        password,
+        fullName,
+        emailRedirectTo: input.emailRedirectTo,
+      })
+    } catch {
+      return {
+        status: SIGN_UP_STATUS.ERROR,
+        error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+      }
+    }
+  }
+}

--- a/lib/auth/supabase-signup-adapter.ts
+++ b/lib/auth/supabase-signup-adapter.ts
@@ -1,0 +1,75 @@
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpResult } from "./contracts"
+import { projectCurrentUser } from "./server-boundary"
+import type { SignupAuthAdapter } from "./signup"
+
+interface SupabaseSignupUser {
+  id: string
+  email?: string | null
+  user_metadata?: Record<string, unknown> | null
+}
+
+interface SupabaseSignupResult {
+  data: {
+    user: SupabaseSignupUser | null
+    session: unknown | null
+  }
+  error: {
+    code?: string
+  } | null
+}
+
+interface SupabaseSignupClient {
+  auth: {
+    signUp(input: {
+      email: string
+      password: string
+      options: {
+        emailRedirectTo: string
+        data: { full_name: string }
+      }
+    }): Promise<SupabaseSignupResult>
+  }
+}
+
+type CreateSupabaseSignupClient = () => SupabaseSignupClient | Promise<SupabaseSignupClient>
+
+export function mapSupabaseSignupResult({ data, error }: SupabaseSignupResult): SignUpResult {
+  if (error || !data.user) {
+    return {
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.PROVIDER_ERROR },
+    }
+  }
+
+  if (!data.session) {
+    return { status: SIGN_UP_STATUS.CONFIRMATION_REQUIRED }
+  }
+
+  return {
+    status: SIGN_UP_STATUS.AUTHENTICATED,
+    user: projectCurrentUser({
+      id: data.user.id,
+      email: data.user.email,
+      userMetadata: data.user.user_metadata,
+    }),
+  }
+}
+
+export function createSupabaseSignupAuthAdapter(createSupabaseClient: CreateSupabaseSignupClient): SignupAuthAdapter {
+  return {
+    async signUp({ email, password, fullName, emailRedirectTo }) {
+      const supabase = await createSupabaseClient()
+
+      return mapSupabaseSignupResult(
+        await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo,
+            data: { full_name: fullName },
+          },
+        })
+      )
+    },
+  }
+}

--- a/tests/integration/auth/signup-feedback.test.ts
+++ b/tests/integration/auth/signup-feedback.test.ts
@@ -2,18 +2,40 @@ import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { SignupFeedback } from "@/components/auth/signup-feedback"
-import { AUTH_ERROR_CODE, type AuthError } from "@/lib/auth/contracts"
+import { AUTH_ERROR_CODE, SIGN_UP_RATE_LIMIT_SCOPE, type SignUpError } from "@/lib/auth/contracts"
 
 describe("signup feedback", () => {
   it.each([
-    [AUTH_ERROR_CODE.RATE_LIMITED, "Demasiados intentos de registro. Espera un momento antes de volver a intentarlo."],
     [AUTH_ERROR_CODE.VALIDATION_FAILED, "Revisa el nombre, el email y las contraseñas e inténtalo de nuevo."],
     [AUTH_ERROR_CODE.PROVIDER_ERROR, "No pudimos crear la cuenta. Inténtalo de nuevo."],
     [AUTH_ERROR_CODE.UNEXPECTED, "Ocurrió un error inesperado. Inténtalo de nuevo."],
   ])("translates %s into Keepel copy", (code, expectedMessage) => {
-    const markup = renderToStaticMarkup(createElement(SignupFeedback, { error: { code } as AuthError }))
+    const markup = renderToStaticMarkup(createElement(SignupFeedback, { error: { code } as SignUpError }))
 
     expect(markup).toContain('role="alert"')
     expect(markup).toContain(expectedMessage)
+  })
+
+  it.each([
+    [SIGN_UP_RATE_LIMIT_SCOPE.IP, "Demasiados intentos de registro desde esta IP. Intenta más tarde."],
+    [
+      SIGN_UP_RATE_LIMIT_SCOPE.EMAIL,
+      "Demasiados intentos de registro para este email. Por seguridad, espera un momento.",
+    ],
+  ])("preserves %s rate-limit guidance", (scope, expectedMessage) => {
+    const markup = renderToStaticMarkup(
+      createElement(SignupFeedback, {
+        error: {
+          code: AUTH_ERROR_CODE.RATE_LIMITED,
+          scope,
+          remaining: 0,
+          limit: 3,
+          reset: Date.now() + 60 * 60 * 1_000,
+        },
+      })
+    )
+
+    expect(markup).toContain(expectedMessage)
+    expect(markup).toContain("Podrás intentar de nuevo en 1 hora(s).")
   })
 })

--- a/tests/integration/auth/signup-feedback.test.ts
+++ b/tests/integration/auth/signup-feedback.test.ts
@@ -1,0 +1,19 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { SignupFeedback } from "@/components/auth/signup-feedback"
+import { AUTH_ERROR_CODE, type AuthError } from "@/lib/auth/contracts"
+
+describe("signup feedback", () => {
+  it.each([
+    [AUTH_ERROR_CODE.RATE_LIMITED, "Demasiados intentos de registro. Espera un momento antes de volver a intentarlo."],
+    [AUTH_ERROR_CODE.VALIDATION_FAILED, "Revisa el nombre, el email y las contraseñas e inténtalo de nuevo."],
+    [AUTH_ERROR_CODE.PROVIDER_ERROR, "No pudimos crear la cuenta. Inténtalo de nuevo."],
+    [AUTH_ERROR_CODE.UNEXPECTED, "Ocurrió un error inesperado. Inténtalo de nuevo."],
+  ])("translates %s into Keepel copy", (code, expectedMessage) => {
+    const markup = renderToStaticMarkup(createElement(SignupFeedback, { error: { code } as AuthError }))
+
+    expect(markup).toContain('role="alert"')
+    expect(markup).toContain(expectedMessage)
+  })
+})

--- a/tests/integration/auth/signup-flow.test.ts
+++ b/tests/integration/auth/signup-flow.test.ts
@@ -60,7 +60,7 @@ describe("signup flow", () => {
       authAdapter: createSupabaseSignupAuthAdapter(async () => supabase),
       rateLimitAdapter: {
         async isAllowed() {
-          return true
+          return { allowed: true }
         },
       },
     })
@@ -148,7 +148,7 @@ describe("signup flow", () => {
       authAdapter: createSupabaseSignupAuthAdapter(async () => supabase),
       rateLimitAdapter: {
         async isAllowed() {
-          return true
+          return { allowed: true }
         },
       },
     })

--- a/tests/integration/auth/signup-flow.test.ts
+++ b/tests/integration/auth/signup-flow.test.ts
@@ -1,0 +1,224 @@
+import { Buffer } from "node:buffer"
+import { createServerClient } from "@supabase/ssr"
+import { describe, expect, it, vi } from "vitest"
+import { runSignupFormAction } from "@/components/auth/signup-form-action"
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS } from "@/lib/auth/contracts"
+import { createSignupCommand } from "@/lib/auth/signup"
+import { createSupabaseSignupAuthAdapter } from "@/lib/auth/supabase-signup-adapter"
+
+function encodeTokenPart(value: object) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url")
+}
+
+function createAccessToken() {
+  return `${encodeTokenPart({ alg: "HS256", typ: "JWT" })}.${encodeTokenPart({ sub: "user-1", exp: 4_102_444_800 })}.signature`
+}
+
+function createSignupUser() {
+  return {
+    id: "user-1",
+    aud: "authenticated",
+    role: "authenticated",
+    email: "driver@example.com",
+    app_metadata: { provider: "email", providers: ["email"] },
+    user_metadata: { full_name: "Ada Driver" },
+    identities: [],
+    created_at: "2026-07-18T00:00:00.000Z",
+  }
+}
+
+describe("signup flow", () => {
+  it("stores an immediate session in SSR cookies and navigates without exposing it to browser code", async () => {
+    const serverCookies = new Map<string, string>()
+    const supabase = createServerClient("https://keepel-test.supabase.co", "test-anon-key", {
+      global: {
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              access_token: createAccessToken(),
+              refresh_token: "server-refresh-token",
+              expires_in: 3600,
+              token_type: "bearer",
+              user: createSignupUser(),
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          ),
+      },
+      cookies: {
+        getAll() {
+          return Array.from(serverCookies, ([name, value]) => ({ name, value }))
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value } of cookiesToSet) {
+            serverCookies.set(name, value)
+          }
+        },
+      },
+    })
+    await supabase.auth.getSession()
+    const signup = createSignupCommand({
+      authAdapter: createSupabaseSignupAuthAdapter(async () => supabase),
+      rateLimitAdapter: {
+        async isAllowed() {
+          return true
+        },
+      },
+    })
+    const navigatedTo: string[] = []
+    const formData = new FormData()
+    formData.set("fullName", "Ada Driver")
+    formData.set("email", "driver@example.com")
+    formData.set("password", "secret-password")
+    formData.set("confirmPassword", "secret-password")
+
+    const forbiddenBrowserSessionAccess = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("browser session data must not be read or written")
+        },
+        ownKeys() {
+          throw new Error("browser session data must not be enumerated")
+        },
+      }
+    )
+    vi.stubGlobal("window", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("document", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("localStorage", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("sessionStorage", forbiddenBrowserSessionAccess)
+
+    try {
+      const result = await runSignupFormAction(null, formData, {
+        signupAction: async (_previousResult, submittedFormData) =>
+          signup({
+            email: submittedFormData.get("email"),
+            password: submittedFormData.get("password"),
+            confirmPassword: submittedFormData.get("confirmPassword"),
+            fullName: submittedFormData.get("fullName"),
+            clientIp: "203.0.113.10",
+            emailRedirectTo: "https://keepel.example/auth/callback",
+          }),
+        onAuthenticated(destination) {
+          navigatedTo.push(destination)
+        },
+        onConfirmationRequired(destination) {
+          navigatedTo.push(destination)
+        },
+      })
+
+      expect(result).toEqual({
+        status: SIGN_UP_STATUS.AUTHENTICATED,
+        user: {
+          id: "user-1",
+          email: "driver@example.com",
+          displayName: "Ada Driver",
+        },
+      })
+      expect(JSON.stringify(result)).not.toMatch(/access.?token|refresh.?token|session/i)
+      expect(Array.from(serverCookies.keys())).toContainEqual(expect.stringMatching(/^sb-keepel-test-auth-token/))
+      expect(navigatedTo).toEqual(["/"])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("navigates to email confirmation when signup does not create a session", async () => {
+    const serverCookies = new Map<string, string>()
+    const supabase = createServerClient("https://keepel-test.supabase.co", "test-anon-key", {
+      global: {
+        fetch: async () =>
+          new Response(JSON.stringify({ user: createSignupUser() }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      },
+      cookies: {
+        getAll() {
+          return Array.from(serverCookies, ([name, value]) => ({ name, value }))
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value } of cookiesToSet) {
+            serverCookies.set(name, value)
+          }
+        },
+      },
+    })
+    await supabase.auth.getSession()
+    const signup = createSignupCommand({
+      authAdapter: createSupabaseSignupAuthAdapter(async () => supabase),
+      rateLimitAdapter: {
+        async isAllowed() {
+          return true
+        },
+      },
+    })
+    const navigatedTo: string[] = []
+    const formData = new FormData()
+    formData.set("fullName", "Ada Driver")
+    formData.set("email", "driver@example.com")
+    formData.set("password", "secret-password")
+    formData.set("confirmPassword", "secret-password")
+
+    const forbiddenBrowserSessionAccess = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("browser session data must not be read or written")
+        },
+        ownKeys() {
+          throw new Error("browser session data must not be enumerated")
+        },
+      }
+    )
+    vi.stubGlobal("window", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("document", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("localStorage", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("sessionStorage", forbiddenBrowserSessionAccess)
+
+    try {
+      const result = await runSignupFormAction(null, formData, {
+        signupAction: async (_previousResult, submittedFormData) =>
+          signup({
+            email: submittedFormData.get("email"),
+            password: submittedFormData.get("password"),
+            confirmPassword: submittedFormData.get("confirmPassword"),
+            fullName: submittedFormData.get("fullName"),
+            clientIp: "203.0.113.10",
+            emailRedirectTo: "https://keepel.example/auth/callback",
+          }),
+        onAuthenticated(destination) {
+          navigatedTo.push(destination)
+        },
+        onConfirmationRequired(destination) {
+          navigatedTo.push(destination)
+        },
+      })
+
+      expect(result).toEqual({ status: SIGN_UP_STATUS.CONFIRMATION_REQUIRED })
+      expect(JSON.stringify(result)).not.toMatch(/access.?token|refresh.?token|session/i)
+      expect(navigatedTo).toEqual(["/auth/signup-success"])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("keeps invalid form input on the client-facing form seam", async () => {
+    const formData = new FormData()
+    formData.set("fullName", "Ada Driver")
+    formData.set("email", "driver@example.com")
+    formData.set("password", "secret-password")
+    formData.set("confirmPassword", "different-password")
+    const result = await runSignupFormAction(null, formData, {
+      async signupAction() {
+        throw new Error("server action should not run")
+      },
+      onAuthenticated() {},
+      onConfirmationRequired() {},
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.VALIDATION_FAILED },
+    })
+  })
+})

--- a/tests/integration/auth/signup.test.ts
+++ b/tests/integration/auth/signup.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest"
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type CurrentUser, type UserId } from "@/lib/auth/contracts"
+import { createSignupCommand, type SignupAuthAdapter, type SignupRateLimitAdapter } from "@/lib/auth/signup"
+
+describe("signup", () => {
+  it("returns the public user when signup creates an immediate session", async () => {
+    const user: CurrentUser = {
+      id: "user-1" as UserId,
+      email: "driver@example.com",
+      displayName: "Ada Driver",
+    }
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        return { status: SIGN_UP_STATUS.AUTHENTICATED, user }
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed() {
+        return true
+      },
+    }
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+
+    const result = await signup({
+      email: "driver@example.com",
+      password: "secret-password",
+      confirmPassword: "secret-password",
+      fullName: "Ada Driver",
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({ status: SIGN_UP_STATUS.AUTHENTICATED, user })
+  })
+
+  it("rejects mismatched passwords before crossing server boundaries", async () => {
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        throw new Error("authentication should not run")
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed() {
+        throw new Error("rate limiting should not run")
+      },
+    }
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+
+    const result = await signup({
+      email: "driver@example.com",
+      password: "secret-password",
+      confirmPassword: "different-password",
+      fullName: "Ada Driver",
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.VALIDATION_FAILED },
+    })
+  })
+
+  it.each([
+    { email: "not-an-email", password: "secret-password", fullName: "Ada Driver" },
+    { email: "driver@example.com", password: "short", fullName: "Ada Driver" },
+    { email: "driver@example.com", password: "secret-password", fullName: "   " },
+  ])("rejects malformed signup fields before crossing server boundaries", async ({ email, password, fullName }) => {
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        throw new Error("authentication should not run")
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed() {
+        throw new Error("rate limiting should not run")
+      },
+    }
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+
+    const result = await signup({
+      email,
+      password,
+      confirmPassword: password,
+      fullName,
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.VALIDATION_FAILED },
+    })
+  })
+
+  it("rate limits the canonical email before creating an account", async () => {
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        throw new Error("authentication should not run")
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed({ email }) {
+        return email !== "driver@example.com"
+      },
+    }
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+
+    const result = await signup({
+      email: "  Driver@Example.com  ",
+      password: "secret-password",
+      confirmPassword: "secret-password",
+      fullName: "Ada Driver",
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.RATE_LIMITED },
+    })
+  })
+
+  it("converts unexpected server failures into the stable unexpected code", async () => {
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        throw new Error("provider connection failed")
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed() {
+        return true
+      },
+    }
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+
+    const result = await signup({
+      email: "driver@example.com",
+      password: "secret-password",
+      confirmPassword: "secret-password",
+      fullName: "Ada Driver",
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+    })
+  })
+})

--- a/tests/integration/auth/signup.test.ts
+++ b/tests/integration/auth/signup.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type CurrentUser, type UserId } from "@/lib/auth/contracts"
+import {
+  AUTH_ERROR_CODE,
+  SIGN_UP_RATE_LIMIT_SCOPE,
+  SIGN_UP_STATUS,
+  type CurrentUser,
+  type UserId,
+} from "@/lib/auth/contracts"
 import { createSignupCommand, type SignupAuthAdapter, type SignupRateLimitAdapter } from "@/lib/auth/signup"
 
 describe("signup", () => {
@@ -16,7 +22,7 @@ describe("signup", () => {
     }
     const rateLimitAdapter: SignupRateLimitAdapter = {
       async isAllowed() {
-        return true
+        return { allowed: true }
       },
     }
     const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
@@ -101,7 +107,15 @@ describe("signup", () => {
     }
     const rateLimitAdapter: SignupRateLimitAdapter = {
       async isAllowed({ email }) {
-        return email !== "driver@example.com"
+        return email === "driver@example.com"
+          ? {
+              allowed: false,
+              scope: SIGN_UP_RATE_LIMIT_SCOPE.EMAIL,
+              remaining: 0,
+              limit: 3,
+              reset: 4_102_444_800_000,
+            }
+          : { allowed: true }
       },
     }
     const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
@@ -117,7 +131,13 @@ describe("signup", () => {
 
     expect(result).toEqual({
       status: SIGN_UP_STATUS.ERROR,
-      error: { code: AUTH_ERROR_CODE.RATE_LIMITED },
+      error: {
+        code: AUTH_ERROR_CODE.RATE_LIMITED,
+        scope: SIGN_UP_RATE_LIMIT_SCOPE.EMAIL,
+        remaining: 0,
+        limit: 3,
+        reset: 4_102_444_800_000,
+      },
     })
   })
 
@@ -129,7 +149,7 @@ describe("signup", () => {
     }
     const rateLimitAdapter: SignupRateLimitAdapter = {
       async isAllowed() {
-        return true
+        return { allowed: true }
       },
     }
     const signup = createSignupCommand({ authAdapter, rateLimitAdapter })

--- a/tests/unit/auth/supabase-signup-adapter.test.ts
+++ b/tests/unit/auth/supabase-signup-adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { AUTH_ERROR_CODE, SIGN_UP_STATUS } from "@/lib/auth/contracts"
+import { createSupabaseSignupAuthAdapter, mapSupabaseSignupResult } from "@/lib/auth/supabase-signup-adapter"
+
+describe("Supabase signup adapter", () => {
+  it("projects an immediate session to a public user without session data", () => {
+    const result = mapSupabaseSignupResult({
+      data: {
+        user: {
+          id: "user-1",
+          email: "driver@example.com",
+          user_metadata: { full_name: "Ada Driver" },
+        },
+        session: {
+          access_token: "server-access-token",
+          refresh_token: "server-refresh-token",
+        },
+      },
+      error: null,
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.AUTHENTICATED,
+      user: {
+        id: "user-1",
+        email: "driver@example.com",
+        displayName: "Ada Driver",
+      },
+    })
+    expect(JSON.stringify(result)).not.toMatch(/access.?token|refresh.?token|session/i)
+  })
+
+  it("distinguishes signup that requires email confirmation", () => {
+    const result = mapSupabaseSignupResult({
+      data: {
+        user: {
+          id: "user-1",
+          email: "driver@example.com",
+          user_metadata: { full_name: "Ada Driver" },
+        },
+        session: null,
+      },
+      error: null,
+    })
+
+    expect(result).toEqual({ status: SIGN_UP_STATUS.CONFIRMATION_REQUIRED })
+  })
+
+  it("returns only Keepel's stable code for provider failures", async () => {
+    const adapter = createSupabaseSignupAuthAdapter(async () => ({
+      auth: {
+        async signUp() {
+          return {
+            data: { user: null, session: null },
+            error: { code: "user_already_exists", message: "User already registered" },
+          }
+        },
+      },
+    }))
+
+    const result = await adapter.signUp({
+      email: "driver@example.com",
+      password: "secret-password",
+      fullName: "Ada Driver",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.PROVIDER_ERROR },
+    })
+    expect(Object.keys(result.status === SIGN_UP_STATUS.ERROR ? result.error : {})).toEqual(["code"])
+  })
+})


### PR DESCRIPTION
## Summary

- migrate email signup to the server-authoritative auth boundary
- distinguish immediate authentication from email-confirmation flows
- preserve typed validation, provider, and rate-limit feedback without exposing tokens

## Impact

Signup now uses the SSR Supabase client and typed Keepel outcomes. Browser code receives only the public user projection or a confirmation-required result.

## Validation

- `bun run test` — 14 files, 79 tests
- `bun type-check`
- `bun run lint`
- targeted `bun run fmt:check`
- `bun run build`

Closes #43