### PR TITLE
Migrate Google OAuth to the server auth boundary

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -2,7 +2,8 @@
 
 import type { NextRequest } from "next/server"
 import { NextResponse } from "next/server"
-import { sanitizeInternalRedirect } from "@/lib/auth/redirects"
+import { OAUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { createOAuthErrorRedirect, sanitizeInternalRedirect } from "@/lib/auth/redirects"
 import { createClient } from "@/lib/supabase/server"
 
 export interface AuthCallbackExchangeResult {
@@ -21,37 +22,35 @@ export function createAuthCallbackHandler(createAdapter: AuthCallbackAdapterFact
     try {
       const { searchParams, origin } = new URL(request.url)
       const code = searchParams.get("code")
-      const error = searchParams.get("error")
+      const providerError = searchParams.get("error")
       const next = sanitizeInternalRedirect(searchParams.get("next"))
 
-      // Si hay un error de OAuth
-      if (error) {
-        return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent(error)}`)
+      if (providerError) {
+        const errorCode =
+          providerError === "access_denied" ? OAUTH_ERROR_CODE.CANCELLED : OAUTH_ERROR_CODE.PROVIDER_ERROR
+        return NextResponse.redirect(createOAuthErrorRedirect(origin, errorCode))
       }
 
-      // Si no hay código, redirigir a error
       if (!code) {
-        return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent("No authorization code")}`)
+        return NextResponse.redirect(createOAuthErrorRedirect(origin, OAUTH_ERROR_CODE.PROVIDER_ERROR))
       }
 
-      // Intentar intercambiar el código por una sesión
       const adapter = await createAdapter()
       const { data, error: exchangeError } = await adapter.exchangeCodeForSession(code)
 
       if (exchangeError) {
-        return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent(exchangeError.message)}`)
+        return NextResponse.redirect(createOAuthErrorRedirect(origin, OAUTH_ERROR_CODE.PROVIDER_ERROR))
       }
 
       if (!data?.user) {
-        return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent("No user found")}`)
+        return NextResponse.redirect(createOAuthErrorRedirect(origin, OAUTH_ERROR_CODE.PROVIDER_ERROR))
       }
 
-      // Éxito - redirigir al destino
       return NextResponse.redirect(new URL(next, origin))
     } catch (error) {
       console.error("Auth callback error:", error)
       const { origin } = new URL(request.url)
-      return NextResponse.redirect(`${origin}/auth/error?message=${encodeURIComponent("Callback failed")}`)
+      return NextResponse.redirect(createOAuthErrorRedirect(origin, OAUTH_ERROR_CODE.UNEXPECTED))
     }
   }
 }

--- a/app/auth/google/route.ts
+++ b/app/auth/google/route.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-console -- OAuth failures need server-side diagnostics until centralized observability is added. */
+
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
+import { OAUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { createOAuthErrorRedirect, sanitizeInternalRedirect } from "@/lib/auth/redirects"
+import { createSupabaseGoogleOAuthAdapter, type GoogleOAuthAdapter } from "@/lib/auth/supabase-google-oauth-adapter"
+import { createClient } from "@/lib/supabase/server"
+
+type GoogleOAuthAdapterFactory = () => GoogleOAuthAdapter | Promise<GoogleOAuthAdapter>
+
+export function createGoogleOAuthHandler(createAdapter: GoogleOAuthAdapterFactory) {
+  return async function handleGoogleOAuth(request: NextRequest) {
+    try {
+      const callbackUrl = new URL("/auth/callback", request.url)
+      callbackUrl.searchParams.set("next", sanitizeInternalRedirect(request.nextUrl.searchParams.get("redirectTo")))
+
+      const adapter = await createAdapter()
+      const oauthStartResult = await adapter.createAuthorizationUrl(callbackUrl.toString())
+
+      return oauthStartResult.started
+        ? NextResponse.redirect(oauthStartResult.authorizationUrl)
+        : NextResponse.redirect(createOAuthErrorRedirect(request.nextUrl.origin, oauthStartResult.errorCode))
+    } catch (error) {
+      console.error("Unexpected Google OAuth initiation failure:", error)
+      return NextResponse.redirect(createOAuthErrorRedirect(request.nextUrl.origin, OAUTH_ERROR_CODE.UNEXPECTED))
+    }
+  }
+}
+
+export const GET = createGoogleOAuthHandler(() =>
+  createSupabaseGoogleOAuthAdapter(createClient, process.env.NEXT_PUBLIC_SUPABASE_URL ?? "")
+)

--- a/components/auth/google-signin-button.tsx
+++ b/components/auth/google-signin-button.tsx
@@ -1,75 +1,42 @@
 "use client"
 
-/* eslint-disable no-console -- OAuth failures are logged locally until centralized observability is added. */
-
 import { useState } from "react"
 import { useAnalytics } from "@/hooks/use-analytics"
-import type { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import { Icons } from "@/components/ui/icons"
-import { useSupabase } from "@/hooks/useSupabase"
 import { sanitizeInternalRedirect } from "@/lib/auth/redirects"
 
 interface GoogleSignInButtonProps {
   redirectTo?: string
   className?: string
   children?: React.ReactNode
-  supabaseClient?: ReturnType<typeof createClient>
 }
 
 export function GoogleSignInButton({
   redirectTo = "/",
   className,
   children = "Continuar con Google",
-  supabaseClient,
 }: GoogleSignInButtonProps) {
   const [isLoading, setIsLoading] = useState(false)
-  const defaultSupabase = useSupabase()
-  // Usar el cliente pasado como prop o el hook por defecto
-  const supabase = supabaseClient || defaultSupabase
   const { trackAuthAction } = useAnalytics()
+  const searchParams = new URLSearchParams({ redirectTo: sanitizeInternalRedirect(redirectTo) })
+  const initiationUrl = `/auth/google?${searchParams.toString()}`
 
-  const handleGoogleSignIn = async () => {
-    try {
-      setIsLoading(true)
-
-      // Track Google sign in attempt
-      trackAuthAction("sign_in", "google")
-
-      // Usar el origen actual y codificar el destino completo dentro del callback.
-      const redirectUrl = new URL("/auth/callback", window.location.origin)
-      redirectUrl.searchParams.set("next", sanitizeInternalRedirect(redirectTo))
-
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: redirectUrl.toString(),
-          queryParams: {
-            access_type: "offline",
-            prompt: "consent",
-          },
-        },
-      })
-
-      if (error) {
-        console.error("Google OAuth error:", error)
-        // Track error
-        trackAuthAction("error", "google")
-        setIsLoading(false)
-      }
-      // No quitamos el loading state si no hay error porque seremos redirigidos
-    } catch (error) {
-      console.error("Unexpected error during Google sign-in:", error)
-      // Track error
-      trackAuthAction("error", "google")
-      setIsLoading(false)
-    }
+  const handleGoogleSignIn = () => {
+    setIsLoading(true)
+    trackAuthAction("sign_in", "google")
   }
 
   return (
-    <Button type="button" variant="outline" onClick={handleGoogleSignIn} disabled={isLoading} className={className}>
-      {isLoading ? <Icons.spinner className="mr-2 h-4 w-4 animate-spin" /> : <Icons.google className="mr-2 h-4 w-4" />}
-      {children}
+    <Button asChild variant="outline" className={className}>
+      <a href={initiationUrl} onClick={handleGoogleSignIn} aria-busy={isLoading}>
+        {isLoading ? (
+          <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Icons.google className="mr-2 h-4 w-4" />
+        )}
+        {children}
+      </a>
     </Button>
   )
 }

--- a/docs/manual-testing/google-oauth.md
+++ b/docs/manual-testing/google-oauth.md
@@ -1,0 +1,25 @@
+# Google OAuth manual verification
+
+The automated auth integration tests cover Keepel's server initiation, PKCE callback exchange, cancellation, and stable error mapping. The Google consent screen itself requires this manual check against a configured Supabase project.
+
+## Prerequisites
+
+- Enable the Google provider in Supabase Auth.
+- Add the Supabase Auth callback URL shown by the provider settings to the Google OAuth client.
+- Add `http://localhost:3000/auth/callback` and the production callback URL to the Supabase redirect allow list.
+- Configure Keepel's Supabase environment variables, then start the app with `bun dev`.
+
+## Successful sign-in
+
+1. Open `http://localhost:3000/auth/login?redirect=/vehicles` in a signed-out browser.
+2. Select **Continuar con Google** and complete the Google consent screen.
+3. Confirm that the browser returns to `/vehicles` and the authenticated UI is visible.
+4. Reload `/vehicles` and confirm that the session remains authenticated through the Supabase SSR cookie.
+5. In browser developer tools, confirm that the flow starts with `GET /auth/google`, and that no access token, refresh token, or session is written to local storage or exposed in a response body or URL.
+
+## Cancellation
+
+1. Start the flow again in a signed-out browser.
+2. Cancel or deny the Google consent request.
+3. Confirm that Keepel opens `/auth/error?error=oauth_cancelled`.
+4. Confirm that the URL and page do not expose Google's error description, authorization code, or any token.

--- a/lib/auth/contracts.ts
+++ b/lib/auth/contracts.ts
@@ -18,6 +18,12 @@ export const AUTH_ERROR_CODE = {
   UNEXPECTED: "unexpected",
 } as const
 
+export const OAUTH_ERROR_CODE = {
+  CANCELLED: "oauth_cancelled",
+  PROVIDER_ERROR: AUTH_ERROR_CODE.PROVIDER_ERROR,
+  UNEXPECTED: AUTH_ERROR_CODE.UNEXPECTED,
+} as const
+
 export const SIGN_UP_STATUS = {
   AUTHENTICATED: "authenticated",
   CONFIRMATION_REQUIRED: "confirmation_required",
@@ -36,6 +42,8 @@ declare const userIdBrand: unique symbol
 export type UserId = string & { readonly [userIdBrand]: "UserId" }
 
 export type AuthErrorCode = ValueOf<typeof AUTH_ERROR_CODE>
+
+export type OAuthErrorCode = ValueOf<typeof OAUTH_ERROR_CODE>
 
 export type SignUpRateLimitScope = ValueOf<typeof SIGN_UP_RATE_LIMIT_SCOPE>
 

--- a/lib/auth/redirects.ts
+++ b/lib/auth/redirects.ts
@@ -1,3 +1,5 @@
+import type { OAuthErrorCode } from "./contracts"
+
 const INTERNAL_REDIRECT_BASE = "https://keepel.invalid"
 const INVALID_PERCENT_ENCODING_PATTERN = /%(?![\da-f]{2})/i
 
@@ -33,4 +35,10 @@ export function sanitizeInternalRedirect(destination: unknown): string {
   } catch {
     return "/"
   }
+}
+
+export function createOAuthErrorRedirect(origin: string, errorCode: OAuthErrorCode): URL {
+  const errorUrl = new URL("/auth/error", origin)
+  errorUrl.searchParams.set("error", errorCode)
+  return errorUrl
 }

--- a/lib/auth/supabase-google-oauth-adapter.ts
+++ b/lib/auth/supabase-google-oauth-adapter.ts
@@ -1,0 +1,89 @@
+import { OAUTH_ERROR_CODE } from "./contracts"
+
+export type GoogleOAuthStartResult =
+  | { started: true; authorizationUrl: string }
+  | { started: false; errorCode: typeof OAUTH_ERROR_CODE.PROVIDER_ERROR }
+
+export interface GoogleOAuthAdapter {
+  createAuthorizationUrl(callbackUrl: string): Promise<GoogleOAuthStartResult>
+}
+
+interface SupabaseGoogleOAuthResult {
+  data: unknown
+  error: unknown
+}
+
+interface SupabaseGoogleOAuthClient {
+  auth: {
+    signInWithOAuth(input: {
+      provider: "google"
+      options: {
+        redirectTo: string
+        queryParams: {
+          access_type: "offline"
+          prompt: "consent"
+        }
+        skipBrowserRedirect: true
+      }
+    }): Promise<SupabaseGoogleOAuthResult>
+  }
+}
+
+type CreateSupabaseGoogleOAuthClient = () => SupabaseGoogleOAuthClient | Promise<SupabaseGoogleOAuthClient>
+
+function isGoogleAuthorizationUrl(value: unknown, supabaseUrl: string): value is string {
+  if (typeof value !== "string") {
+    return false
+  }
+
+  try {
+    const expectedUrl = new URL("/auth/v1/authorize", supabaseUrl)
+    const authorizationUrl = new URL(value)
+
+    return (
+      (expectedUrl.protocol === "https:" || expectedUrl.protocol === "http:") &&
+      authorizationUrl.origin === expectedUrl.origin &&
+      authorizationUrl.pathname === expectedUrl.pathname &&
+      authorizationUrl.username === "" &&
+      authorizationUrl.password === "" &&
+      authorizationUrl.searchParams.get("provider") === "google"
+    )
+  } catch {
+    return false
+  }
+}
+
+export function createSupabaseGoogleOAuthAdapter(
+  createSupabaseClient: CreateSupabaseGoogleOAuthClient,
+  supabaseUrl: string
+): GoogleOAuthAdapter {
+  return {
+    async createAuthorizationUrl(callbackUrl) {
+      const supabase = await createSupabaseClient()
+      const providerResult = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: callbackUrl,
+          queryParams: {
+            access_type: "offline",
+            prompt: "consent",
+          },
+          skipBrowserRedirect: true,
+        },
+      })
+
+      const authorizationUrl =
+        typeof providerResult.data === "object" &&
+        providerResult.data !== null &&
+        "url" in providerResult.data &&
+        "provider" in providerResult.data &&
+        providerResult.data.provider === "google"
+          ? providerResult.data.url
+          : null
+
+      return providerResult.error === null && isGoogleAuthorizationUrl(authorizationUrl, supabaseUrl)
+        ? { started: true, authorizationUrl }
+        : { started: false, errorCode: OAUTH_ERROR_CODE.PROVIDER_ERROR }
+    },
+  }
+}

--- a/tests/integration/auth/callback.test.ts
+++ b/tests/integration/auth/callback.test.ts
@@ -34,4 +34,32 @@ describe("auth callback", () => {
 
     expect(response.headers.get("location")).toBe("https://keepel.example/")
   })
+
+  it("maps provider cancellation to a stable browser-visible error", async () => {
+    const handleCallback = createAuthCallbackHandler(async () => {
+      throw new Error("the callback exchange must not run after provider cancellation")
+    })
+    const request = new NextRequest(
+      "https://keepel.example/auth/callback?error=access_denied&error_description=Sensitive+provider+details"
+    )
+
+    const response = await handleCallback(request)
+
+    expect(response.headers.get("location")).toBe("https://keepel.example/auth/error?error=oauth_cancelled")
+    expect(response.headers.get("location")).not.toMatch(/access_denied|Sensitive|provider.details/i)
+  })
+
+  it("maps callback exchange failures to a stable browser-visible error", async () => {
+    const adapter = createControlledAuthCallbackAdapter({
+      data: null,
+      error: { message: "Sensitive provider exchange details" },
+    })
+    const handleCallback = createAuthCallbackHandler(async () => adapter)
+    const request = new NextRequest("https://keepel.example/auth/callback?code=invalid-code")
+
+    const response = await handleCallback(request)
+
+    expect(response.headers.get("location")).toBe("https://keepel.example/auth/error?error=provider_error")
+    expect(response.headers.get("location")).not.toMatch(/Sensitive|exchange.details/i)
+  })
 })

--- a/tests/integration/auth/google-oauth-flow.test.ts
+++ b/tests/integration/auth/google-oauth-flow.test.ts
@@ -1,0 +1,145 @@
+import { NextRequest } from "next/server"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { Buffer } from "node:buffer"
+import { createServerClient } from "@supabase/ssr"
+import { describe, expect, it } from "vitest"
+import { createAuthCallbackHandler } from "@/app/auth/callback/route"
+import { createGoogleOAuthHandler } from "@/app/auth/google/route"
+import { GoogleSignInButton } from "@/components/auth/google-signin-button"
+import { OAUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { createSupabaseGoogleOAuthAdapter } from "@/lib/auth/supabase-google-oauth-adapter"
+
+function encodeTokenPart(value: object) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url")
+}
+
+function createAccessToken() {
+  return `${encodeTokenPart({ alg: "HS256", typ: "JWT" })}.${encodeTokenPart({ sub: "user-1", exp: 4_102_444_800 })}.signature`
+}
+
+function createTestCookieStore() {
+  const values = new Map<string, string>()
+
+  return {
+    values,
+    cookies: {
+      getAll() {
+        return Array.from(values, ([name, value]) => ({ name, value }))
+      },
+      setAll(cookiesToSet: Array<{ name: string; value: string }>) {
+        for (const { name, value } of cookiesToSet) {
+          values.set(name, value)
+        }
+      },
+    },
+  }
+}
+
+describe("Google OAuth flow", () => {
+  it("starts Google OAuth on the server with a PKCE cookie and a sanitized callback destination", async () => {
+    const serverCookies = createTestCookieStore()
+    const supabase = createServerClient("https://keepel-test.supabase.co", "test-anon-key", {
+      cookies: serverCookies.cookies,
+    })
+    const handleGoogleOAuth = createGoogleOAuthHandler(async () =>
+      createSupabaseGoogleOAuthAdapter(async () => supabase, "https://keepel-test.supabase.co")
+    )
+    const request = new NextRequest(
+      "https://keepel.example/auth/google?redirectTo=https%3A%2F%2Fevil.example%2Fphishing"
+    )
+
+    const response = await handleGoogleOAuth(request)
+
+    const authorizationUrl = new URL(response.headers.get("location") ?? "")
+    expect(authorizationUrl.origin).toBe("https://keepel-test.supabase.co")
+    expect(authorizationUrl.pathname).toBe("/auth/v1/authorize")
+    expect(authorizationUrl.searchParams.get("provider")).toBe("google")
+    expect(authorizationUrl.searchParams.get("redirect_to")).toBe("https://keepel.example/auth/callback?next=%2F")
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("s256")
+    expect(authorizationUrl.searchParams.get("code_challenge")).toEqual(expect.any(String))
+    expect(Array.from(serverCookies.values.keys())).toEqual([
+      expect.stringMatching(/^sb-keepel-test-auth-token-code-verifier/),
+    ])
+    expect(await response.text()).toBe("")
+  })
+
+  it("renders a server initiation link instead of a browser auth control", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GoogleSignInButton, {
+        redirectTo: "/vehicles/vehicle-1?tab=maintenance#record-42",
+      })
+    )
+
+    expect(markup).toContain('href="/auth/google?redirectTo=%2Fvehicles%2Fvehicle-1%3Ftab%3Dmaintenance%23record-42"')
+    expect(markup).not.toContain('type="button"')
+  })
+
+  it("rejects an authorization URL outside the configured Supabase origin", async () => {
+    const adapter = createSupabaseGoogleOAuthAdapter(
+      async () => ({
+        auth: {
+          async signInWithOAuth() {
+            return {
+              data: { provider: "google", url: "https://evil.example/auth/v1/authorize?provider=google" },
+              error: null,
+            }
+          },
+        },
+      }),
+      "https://keepel-test.supabase.co"
+    )
+
+    const oauthStartResult = await adapter.createAuthorizationUrl("https://keepel.example/auth/callback")
+
+    expect(oauthStartResult).toEqual({ started: false, errorCode: OAUTH_ERROR_CODE.PROVIDER_ERROR })
+  })
+
+  it("exchanges the callback code on the server and stores the session in SSR cookies", async () => {
+    const serverCookies = createTestCookieStore()
+    const supabase = createServerClient("https://keepel-test.supabase.co", "test-anon-key", {
+      global: {
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              access_token: createAccessToken(),
+              refresh_token: "server-refresh-token",
+              expires_in: 3600,
+              token_type: "bearer",
+              user: {
+                id: "user-1",
+                aud: "authenticated",
+                role: "authenticated",
+                email: "driver@example.com",
+                app_metadata: { provider: "google", providers: ["google"] },
+                user_metadata: {},
+                identities: [],
+                created_at: "2026-07-19T00:00:00.000Z",
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          ),
+      },
+      cookies: serverCookies.cookies,
+    })
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: "https://keepel.example/auth/callback?next=%2Fvehicles" },
+    })
+    const handleCallback = createAuthCallbackHandler(async () => ({
+      exchangeCodeForSession(code) {
+        return supabase.auth.exchangeCodeForSession(code)
+      },
+    }))
+    const request = new NextRequest(
+      "https://keepel.example/auth/callback?code=valid-code&next=%2Fvehicles%3Ffilter%3Ddue"
+    )
+
+    const response = await handleCallback(request)
+
+    expect(response.headers.get("location")).toBe("https://keepel.example/vehicles?filter=due")
+    expect(Array.from(serverCookies.values.keys())).toContainEqual(expect.stringMatching(/^sb-keepel-test-auth-token$/))
+    expect(response.headers.get("location")).not.toMatch(/access.?token|refresh.?token|session/i)
+    expect(await response.text()).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary

- start Google OAuth through a same-origin server route backed by the Supabase SSR PKCE flow
- remove browser-side Supabase Auth calls from the Google sign-in control
- exchange callback codes on the server, sanitize return destinations, and expose only typed stable errors
- validate Supabase authorization URLs at the adapter boundary
- cover initiation, successful callback, cancellation, and failures; document the real Google consent-screen check

## Why

Google OAuth still initiated through the browser Supabase client, while callback failures exposed provider messages directly. That conflicted with the server-authoritative authentication architecture in #39.

## Impact

Google login now creates and exchanges PKCE/session state through the server boundary. Browser-visible state contains only the navigation URL or stable Keepel error codes, and unsafe return destinations fall back to the application root.

## Validation

- `bun run test` — 15 files, 85 tests
- `bun run type-check`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`
- final Standards and Spec review: no unresolved findings

Closes #44