### PR TITLE
feat(auth): centralize logout and session recovery

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-console -- Server actions log unexpected auth failures until centralized observability is added. */
 
+import { revalidatePath } from "next/cache"
 import { headers } from "next/headers"
 import {
   AUTH_COMMAND_STATUS,
@@ -11,9 +12,11 @@ import {
   type SignUpResult,
 } from "@/lib/auth/contracts"
 import { createPasswordLoginCommand, type PasswordLoginResult } from "@/lib/auth/password-login"
-import { getCurrentUser } from "@/lib/auth/server"
+import { createLogoutCommand, type LogoutResult } from "@/lib/auth/logout"
+import { getCurrentUser, requireCurrentUser } from "@/lib/auth/server"
 import { createSignupCommand } from "@/lib/auth/signup"
 import { createSupabasePasswordLoginAuthAdapter } from "@/lib/auth/supabase-password-login-adapter"
+import { createSupabaseLogoutAuthAdapter } from "@/lib/auth/supabase-logout-adapter"
 import { createSupabaseSignupAuthAdapter } from "@/lib/auth/supabase-signup-adapter"
 import { loginRateLimiter, signupRateLimiter } from "@/lib/ratelimit"
 import { createClient } from "@/lib/supabase/server"
@@ -30,6 +33,11 @@ const passwordLogin = createPasswordLoginCommand({
       return emailLimit.success && ipLimit.success
     },
   },
+})
+
+const logout = createLogoutCommand({
+  authAdapter: createSupabaseLogoutAuthAdapter(createClient),
+  requireCurrentUser,
 })
 
 const signup = createSignupCommand({
@@ -90,6 +98,16 @@ export async function loginAction(
       error: { code: AUTH_ERROR_CODE.UNEXPECTED },
     }
   }
+}
+
+export async function logoutAction(_previousResult: LogoutResult | null, _formData: FormData): Promise<LogoutResult> {
+  const result = await logout()
+
+  if (result.status === AUTH_COMMAND_STATUS.SUCCESS) {
+    revalidatePath("/", "layout")
+  }
+
+  return result
 }
 
 export async function signupAction(_previousResult: SignUpResult | null, formData: FormData): Promise<SignUpResult> {

--- a/components/auth/logout-control.tsx
+++ b/components/auth/logout-control.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useActionState, type ReactNode } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { logoutAction } from "@/app/auth/actions"
+import { useAuthProjectionInvalidation } from "@/contexts"
+import { useAuthCommandRecovery } from "@/hooks"
+import type { LogoutResult } from "@/lib/auth/logout"
+import { runLogoutFormAction } from "./logout-form-action"
+
+interface LogoutControlProps {
+  children(state: { isPending: boolean }): ReactNode
+  className?: string
+  onAttempt?: () => void
+  onError?: () => void
+}
+
+export function LogoutControl({ children, className, onAttempt, onError }: LogoutControlProps) {
+  const invalidateProjection = useAuthProjectionInvalidation()
+  const recoverSession = useAuthCommandRecovery()
+  const router = useRouter()
+  const [, formAction, isPending] = useActionState(
+    (previousResult: LogoutResult | null, formData: FormData) =>
+      runLogoutFormAction(previousResult, formData, {
+        logoutAction,
+        onAttempt() {
+          onAttempt?.()
+        },
+        onSuccess() {
+          invalidateProjection()
+          router.replace("/auth/login")
+          router.refresh()
+        },
+        onError(result) {
+          onError?.()
+
+          if (!recoverSession(result)) {
+            toast.error("No se pudo cerrar la sesión. Inténtalo de nuevo.")
+          }
+        },
+      }),
+    null
+  )
+
+  return (
+    <form action={formAction} aria-busy={isPending} className={className}>
+      {children({ isPending })}
+    </form>
+  )
+}

--- a/components/auth/logout-form-action.ts
+++ b/components/auth/logout-form-action.ts
@@ -1,0 +1,26 @@
+import { AUTH_COMMAND_STATUS } from "@/lib/auth/contracts"
+import type { LogoutResult } from "@/lib/auth/logout"
+
+interface LogoutFormActionDependencies {
+  logoutAction(previousResult: LogoutResult | null, formData: FormData): Promise<LogoutResult>
+  onAttempt(): void
+  onSuccess(): void
+  onError(result: LogoutResult): void
+}
+
+export async function runLogoutFormAction(
+  previousResult: LogoutResult | null,
+  formData: FormData,
+  dependencies: LogoutFormActionDependencies
+): Promise<LogoutResult> {
+  dependencies.onAttempt()
+  const result = await dependencies.logoutAction(previousResult, formData)
+
+  if (result.status === AUTH_COMMAND_STATUS.SUCCESS) {
+    dependencies.onSuccess()
+  } else {
+    dependencies.onError(result)
+  }
+
+  return result
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,11 +1,15 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
 import { Car, User, LogOut, Plus, ChevronDown, Menu } from "lucide-react"
 
+import { useAuth, useData } from "@/contexts"
+import { useAnalytics } from "@/hooks"
+import { LogoutControl } from "@/components/auth/logout-control"
+import { HeaderSkeleton } from "@/components/skeletons/header-skeleton"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -16,53 +20,22 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger, SheetClose } from "@/components/ui/sheet"
-import { useAuth, useData } from "@/contexts"
-import { HeaderSkeleton } from "@/components/skeletons/header-skeleton"
 
 export function Header() {
-  const { user, profile, isLoading: authLoading, isLoggingOut, signOut } = useAuth()
+  const { user, profile, isLoading: authLoading } = useAuth()
   const { vehicles } = useData()
+  const { trackAuthAction } = useAnalytics()
   const [showVehiclesDropdown, setShowVehiclesDropdown] = useState(false)
   const [showUserDropdown, setShowUserDropdown] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const router = useRouter()
 
-  // Safety timeout: if logout takes more than 2 seconds, force redirect
-  useEffect(() => {
-    if (isLoggingOut) {
-      const timeoutId = setTimeout(() => {
-        window.location.replace("/auth/login")
-      }, 2000)
-
-      return () => {
-        clearTimeout(timeoutId)
-      }
-    }
-  }, [isLoggingOut])
-
-  const handleSignOut = async () => {
-    setShowUserDropdown(false)
-    setMobileMenuOpen(false)
-    await signOut()
+  const handleLogoutAttempt = () => {
+    trackAuthAction("sign_out")
   }
 
-  // Mostrar pantalla de carga completa durante logout
-  if (isLoggingOut) {
-    return (
-      <div className="bg-background/95 fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-sm">
-        <div className="flex flex-col items-center gap-4">
-          <Image src="/logo_keepel_grueso.svg" alt="Keepel" width={48} height={48} className="animate-pulse" />
-          <div className="flex flex-col items-center gap-2">
-            <p className="text-foreground text-xl font-semibold">Cerrando sesión...</p>
-          </div>
-          <div className="flex gap-2">
-            <div className="bg-primary h-2 w-2 animate-bounce rounded-full [animation-delay:-0.3s]"></div>
-            <div className="bg-primary h-2 w-2 animate-bounce rounded-full [animation-delay:-0.15s]"></div>
-            <div className="bg-primary h-2 w-2 animate-bounce rounded-full"></div>
-          </div>
-        </div>
-      </div>
-    )
+  const handleLogoutError = () => {
+    trackAuthAction("error", "sign_out")
   }
 
   // Mostrar skeleton durante la carga inicial para evitar parpadeo
@@ -161,10 +134,16 @@ export function Header() {
 
                   <DropdownMenuSeparator />
 
-                  <DropdownMenuItem onClick={handleSignOut} className="cursor-pointer">
-                    <LogOut className="mr-2 h-4 w-4" />
-                    <span>Cerrar Sesión</span>
-                  </DropdownMenuItem>
+                  <LogoutControl className="w-full" onAttempt={handleLogoutAttempt} onError={handleLogoutError}>
+                    {({ isPending }) => (
+                      <DropdownMenuItem asChild disabled={isPending} onSelect={(event) => event.preventDefault()}>
+                        <button type="submit" className="w-full cursor-pointer">
+                          <LogOut className="mr-2 h-4 w-4" />
+                          <span>{isPending ? "Cerrando sesión..." : "Cerrar Sesión"}</span>
+                        </button>
+                      </DropdownMenuItem>
+                    )}
+                  </LogoutControl>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -243,14 +222,19 @@ export function Header() {
 
                     {/* Actions Section */}
                     <div className="border-border mt-auto space-y-2 border-t pt-4">
-                      <Button
-                        variant="ghost"
-                        className="hover:bg-destructive/10 hover:text-destructive w-full justify-start gap-3"
-                        onClick={handleSignOut}
-                      >
-                        <LogOut className="h-5 w-5" />
-                        <span>Cerrar Sesión</span>
-                      </Button>
+                      <LogoutControl className="w-full" onAttempt={handleLogoutAttempt} onError={handleLogoutError}>
+                        {({ isPending }) => (
+                          <Button
+                            type="submit"
+                            variant="ghost"
+                            className="hover:bg-destructive/10 hover:text-destructive w-full justify-start gap-3"
+                            disabled={isPending}
+                          >
+                            <LogOut className="h-5 w-5" />
+                            <span>{isPending ? "Cerrando sesión..." : "Cerrar Sesión"}</span>
+                          </Button>
+                        )}
+                      </LogoutControl>
                     </div>
                   </div>
                 </SheetContent>

--- a/contexts/AuthProjectionContext.tsx
+++ b/contexts/AuthProjectionContext.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { createContext, useContext, type ReactNode } from "react"
-import type { AuthState } from "@/lib/auth/contracts"
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react"
+import { AUTH_STATE_STATUS, type AuthState } from "@/lib/auth/contracts"
 
 const AuthProjectionContext = createContext<AuthState | null>(null)
+const AuthProjectionInvalidationContext = createContext<(() => void) | null>(null)
 
 interface AuthProjectionProviderProps {
   children?: ReactNode
@@ -11,7 +12,21 @@ interface AuthProjectionProviderProps {
 }
 
 export function AuthProjectionProvider({ children, initialState }: AuthProjectionProviderProps) {
-  return <AuthProjectionContext.Provider value={initialState}>{children}</AuthProjectionContext.Provider>
+  const [state, setState] = useState(initialState)
+
+  useEffect(() => {
+    setState(initialState)
+  }, [initialState])
+
+  const invalidate = useCallback(() => {
+    setState({ status: AUTH_STATE_STATUS.ANONYMOUS, user: null })
+  }, [])
+
+  return (
+    <AuthProjectionInvalidationContext.Provider value={invalidate}>
+      <AuthProjectionContext.Provider value={state}>{children}</AuthProjectionContext.Provider>
+    </AuthProjectionInvalidationContext.Provider>
+  )
 }
 
 export function useAuthProjection() {
@@ -22,4 +37,14 @@ export function useAuthProjection() {
   }
 
   return state
+}
+
+export function useAuthProjectionInvalidation() {
+  const invalidate = useContext(AuthProjectionInvalidationContext)
+
+  if (!invalidate) {
+    throw new Error("useAuthProjectionInvalidation must be used within an AuthProjectionProvider")
+  }
+
+  return invalidate
 }

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,7 +1,7 @@
 // Context exports
 export { AppProviders } from "./AppProviders"
 export { AuthProvider, useAuth } from "./AuthContext"
-export { AuthProjectionProvider, useAuthProjection } from "./AuthProjectionContext"
+export { AuthProjectionProvider, useAuthProjection, useAuthProjectionInvalidation } from "./AuthProjectionContext"
 export { DataProvider, useData } from "./DataContext"
 export { SupabaseProvider, useSupabase } from "./SupabaseContext"
 

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -11,6 +11,7 @@ export { useDashboardData } from "./useDashboardData"
 
 // Analytics hook
 export { useAnalytics } from "./use-analytics"
+export { useAuthCommandRecovery } from "./use-auth-command-recovery"
 
 // UI hooks
 export { useMediaQuery } from "./use-media-query"

--- a/hooks/use-auth-command-recovery.ts
+++ b/hooks/use-auth-command-recovery.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { useAuthProjectionInvalidation } from "@/contexts"
+import type { AuthCommandResult } from "@/lib/auth/contracts"
+import { createSessionExpiredRecovery } from "@/lib/auth/session-expiry-recovery"
+
+function readCurrentPath() {
+  if (typeof window === "undefined") {
+    return "/"
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+export function useAuthCommandRecovery() {
+  const invalidateProjection = useAuthProjectionInvalidation()
+  const router = useRouter()
+
+  return useCallback(
+    (result: AuthCommandResult<unknown>) =>
+      createSessionExpiredRecovery({
+        invalidateProjection,
+        navigate: router.replace,
+        refreshNavigation: router.refresh,
+      })(result, readCurrentPath()),
+    [invalidateProjection, router]
+  )
+}

--- a/lib/auth/logout.ts
+++ b/lib/auth/logout.ts
@@ -1,0 +1,24 @@
+import { type AuthCommandResult, type CurrentUser } from "./contracts"
+import { createPrivateAuthCommand } from "./private-command"
+
+export type LogoutResult = AuthCommandResult<null>
+
+export interface LogoutAuthAdapter {
+  signOut(): Promise<LogoutResult>
+}
+
+interface LogoutDependencies {
+  authAdapter: LogoutAuthAdapter
+  requireCurrentUser(): Promise<CurrentUser>
+}
+
+export function createLogoutCommand({ authAdapter, requireCurrentUser }: LogoutDependencies) {
+  const runLogout = createPrivateAuthCommand<void, null>({
+    requireCurrentUser,
+    execute: () => authAdapter.signOut(),
+  })
+
+  return async function logout(): Promise<LogoutResult> {
+    return runLogout()
+  }
+}

--- a/lib/auth/private-command.ts
+++ b/lib/auth/private-command.ts
@@ -1,0 +1,47 @@
+import {
+  AUTH_COMMAND_STATUS,
+  AUTH_ERROR_CODE,
+  type AuthCommandResult,
+  type AuthErrorCode,
+  type CurrentUser,
+} from "./contracts"
+
+interface PrivateAuthCommandDependencies<Input, SuccessData> {
+  requireCurrentUser(): Promise<CurrentUser>
+  execute(input: Input, user: CurrentUser): Promise<AuthCommandResult<SuccessData>>
+}
+
+function hasAuthErrorCode(error: unknown, code: AuthErrorCode) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code
+}
+
+export function createPrivateAuthCommand<Input, SuccessData>({
+  requireCurrentUser,
+  execute,
+}: PrivateAuthCommandDependencies<Input, SuccessData>) {
+  return async function runPrivateAuthCommand(input: Input): Promise<AuthCommandResult<SuccessData>> {
+    let user: CurrentUser
+
+    try {
+      user = await requireCurrentUser()
+    } catch (error) {
+      return {
+        status: AUTH_COMMAND_STATUS.ERROR,
+        error: {
+          code: hasAuthErrorCode(error, AUTH_ERROR_CODE.AUTHENTICATION_REQUIRED)
+            ? AUTH_ERROR_CODE.SESSION_EXPIRED
+            : AUTH_ERROR_CODE.UNEXPECTED,
+        },
+      }
+    }
+
+    try {
+      return await execute(input, user)
+    } catch {
+      return {
+        status: AUTH_COMMAND_STATUS.ERROR,
+        error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+      }
+    }
+  }
+}

--- a/lib/auth/session-expiry-recovery.ts
+++ b/lib/auth/session-expiry-recovery.ts
@@ -1,0 +1,28 @@
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, type AuthCommandResult } from "./contracts"
+import { sanitizeInternalRedirect } from "./redirects"
+
+interface SessionExpiredRecoveryDependencies {
+  invalidateProjection(): void
+  navigate(destination: string): void
+  refreshNavigation(): void
+}
+
+export function createSessionExpiredRecovery({
+  invalidateProjection,
+  navigate,
+  refreshNavigation,
+}: SessionExpiredRecoveryDependencies) {
+  return function recoverSession(result: AuthCommandResult<unknown>, returnTo: unknown) {
+    if (result.status !== AUTH_COMMAND_STATUS.ERROR || result.error.code !== AUTH_ERROR_CODE.SESSION_EXPIRED) {
+      return false
+    }
+
+    const searchParams = new URLSearchParams({ redirect: sanitizeInternalRedirect(returnTo) })
+
+    invalidateProjection()
+    navigate(`/auth/login?${searchParams.toString()}`)
+    refreshNavigation()
+
+    return true
+  }
+}

--- a/lib/auth/supabase-logout-adapter.ts
+++ b/lib/auth/supabase-logout-adapter.ts
@@ -1,0 +1,35 @@
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE } from "./contracts"
+import type { LogoutAuthAdapter, LogoutResult } from "./logout"
+
+interface SupabaseLogoutClient {
+  auth: {
+    signOut(options: { scope: "local" }): Promise<unknown>
+  }
+}
+
+type CreateSupabaseLogoutClient = () => SupabaseLogoutClient | Promise<SupabaseLogoutClient>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function mapSupabaseLogoutResult(result: unknown): LogoutResult {
+  if (!isRecord(result) || !("error" in result) || result.error !== null) {
+    return {
+      status: AUTH_COMMAND_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.PROVIDER_ERROR },
+    }
+  }
+
+  return { status: AUTH_COMMAND_STATUS.SUCCESS, data: null }
+}
+
+export function createSupabaseLogoutAuthAdapter(createSupabaseClient: CreateSupabaseLogoutClient): LogoutAuthAdapter {
+  return {
+    async signOut() {
+      const supabase = await createSupabaseClient()
+
+      return mapSupabaseLogoutResult(await supabase.auth.signOut({ scope: "local" }))
+    },
+  }
+}

--- a/tests/integration/auth/logout-control.test.ts
+++ b/tests/integration/auth/logout-control.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest"
+import { AUTH_COMMAND_STATUS } from "@/lib/auth/contracts"
+import { runLogoutFormAction } from "@/components/auth/logout-form-action"
+
+describe("logout control", () => {
+  it("invalidates the auth projection and refreshes navigation after the server transition succeeds", async () => {
+    const transitionEvents: string[] = []
+    const logoutAction = vi.fn(async () => ({
+      status: AUTH_COMMAND_STATUS.SUCCESS,
+      data: null,
+    }))
+
+    const result = await runLogoutFormAction(null, new FormData(), {
+      logoutAction,
+      onAttempt() {
+        transitionEvents.push("attempt")
+      },
+      onSuccess() {
+        transitionEvents.push("invalidate")
+        transitionEvents.push("navigate:/auth/login")
+        transitionEvents.push("refresh")
+      },
+      onError() {
+        transitionEvents.push("error")
+      },
+    })
+
+    expect(logoutAction).toHaveBeenCalledOnce()
+    expect(result).toEqual({ status: AUTH_COMMAND_STATUS.SUCCESS, data: null })
+    expect(transitionEvents).toEqual(["attempt", "invalidate", "navigate:/auth/login", "refresh"])
+  })
+})

--- a/tests/integration/auth/logout-flow.test.ts
+++ b/tests/integration/auth/logout-flow.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest"
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { createLogoutCommand } from "@/lib/auth/logout"
+import { createAuthServerApi } from "@/lib/auth/server-boundary"
+import { createSupabaseLogoutAuthAdapter } from "@/lib/auth/supabase-logout-adapter"
+import { createControlledAuthServerAdapter } from "@/tests/support/controlled-auth-server-adapter"
+
+describe("logout flow", () => {
+  it("destroys only the server-side local session without accessing browser auth storage", async () => {
+    const receivedOptions: unknown[] = []
+    const privateAuth = createAuthServerApi(
+      createControlledAuthServerAdapter({ id: "user-1", email: "driver@example.com" })
+    )
+    const logout = createLogoutCommand({
+      requireCurrentUser: privateAuth.requireCurrentUser,
+      authAdapter: createSupabaseLogoutAuthAdapter(async () => ({
+        auth: {
+          async signOut(options) {
+            receivedOptions.push(options)
+            return { error: null }
+          },
+        },
+      })),
+    })
+    const forbiddenBrowserSessionAccess = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("browser session data must not be read or written")
+        },
+        ownKeys() {
+          throw new Error("browser session data must not be enumerated")
+        },
+      }
+    )
+    vi.stubGlobal("window", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("document", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("localStorage", forbiddenBrowserSessionAccess)
+    vi.stubGlobal("sessionStorage", forbiddenBrowserSessionAccess)
+
+    try {
+      const result = await logout()
+
+      expect(receivedOptions).toEqual([{ scope: "local" }])
+      expect(result).toEqual({ status: AUTH_COMMAND_STATUS.SUCCESS, data: null })
+      expect(JSON.stringify(result)).not.toMatch(/access.?token|refresh.?token|session/i)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("returns session expired without contacting logout when the private user is missing", async () => {
+    const privateAuth = createAuthServerApi(createControlledAuthServerAdapter(null))
+    const signOut = vi.fn(async () => ({ error: null }))
+    const logout = createLogoutCommand({
+      requireCurrentUser: privateAuth.requireCurrentUser,
+      authAdapter: createSupabaseLogoutAuthAdapter(async () => ({ auth: { signOut } })),
+    })
+
+    const result = await logout()
+
+    expect(signOut).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      status: AUTH_COMMAND_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.SESSION_EXPIRED },
+    })
+  })
+})

--- a/tests/integration/auth/session-expiry-recovery.test.ts
+++ b/tests/integration/auth/session-expiry-recovery.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest"
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { createPrivateAuthCommand } from "@/lib/auth/private-command"
+import { createSessionExpiredRecovery } from "@/lib/auth/session-expiry-recovery"
+import { createAuthServerApi } from "@/lib/auth/server-boundary"
+import { createControlledAuthServerAdapter } from "@/tests/support/controlled-auth-server-adapter"
+
+describe("session expiry recovery", () => {
+  it("maps a missing private user to session expiry and recovers through the sanitized login path", async () => {
+    const privateAuth = createAuthServerApi(createControlledAuthServerAdapter(null))
+    const execute = vi.fn(async () => ({
+      status: AUTH_COMMAND_STATUS.SUCCESS,
+      data: { vehicleId: "vehicle-1" },
+    }))
+    const privateCommand = createPrivateAuthCommand({
+      requireCurrentUser: privateAuth.requireCurrentUser,
+      execute,
+    })
+    const recoveryEvents: string[] = []
+    const recoverSession = createSessionExpiredRecovery({
+      invalidateProjection() {
+        recoveryEvents.push("invalidate")
+      },
+      navigate(destination) {
+        recoveryEvents.push(`navigate:${destination}`)
+      },
+      refreshNavigation() {
+        recoveryEvents.push("refresh")
+      },
+    })
+
+    const result = await privateCommand({ vehicleId: "vehicle-1" })
+    const recovered = recoverSession(result, "https://evil.example/phishing")
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      status: AUTH_COMMAND_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.SESSION_EXPIRED },
+    })
+    expect(recovered).toBe(true)
+    expect(recoveryEvents).toEqual(["invalidate", "navigate:/auth/login?redirect=%2F", "refresh"])
+  })
+})


### PR DESCRIPTION
## Summary

- Add a server-authoritative logout command using Supabase's local session scope.
- Keep logout pending state local to each desktop/mobile control and refresh the auth projection after success.
- Return `session_expired` from private commands and recover through a sanitized login redirect.
- Add integration coverage for logout, expired sessions, and projection recovery.

## Why

Ticket #46 migrates logout and expired-session recovery to centralized typed commands while preserving the incremental auth migration boundaries for tickets #47, #49, and #50.

## Validation

- `bun fmt:check`
- `bun lint`
- `bun type-check`
- `bun run test` (95 tests)
- `bun run build`

Closes #46