### PR TITLE
feat(auth): project visible identity from server (#47)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,11 +131,12 @@ The app follows a clean architecture with these layers:
 
 #### Authentication Flow
 
-The auth system is event-driven with three layers:
+The auth system is migrating incrementally to a server-authoritative projection:
 
 1. **AuthManager** — Singleton that manages Supabase client and broadcasts state changes via BroadcastChannel
-2. **AuthProvider** — React context that exposes user, profile, signOut
-3. **DataProvider** — Loads vehicles and maintenance with optimistic updates
+2. **AuthProjectionProvider** — React projection seeded by the server with typed `CurrentUser` identity
+3. **AuthProvider** — Compatibility context for data/form consumers until the legacy migration is complete
+4. **DataProvider** — Loads vehicles and maintenance with optimistic updates
 
 #### Data Flow
 
@@ -378,14 +379,15 @@ CarCare/
 
 ### Contexts & Hooks
 
-| Item                 | Import       | Exposes                                 |
-| -------------------- | ------------ | --------------------------------------- |
-| `useAuth()`          | `@/contexts` | user, profile, isAuthenticated, signOut |
-| `useData()`          | `@/contexts` | vehicles, maintenance, CRUD methods     |
-| `useSupabase()`      | `@/contexts` | Raw Supabase client                     |
-| `useDashboardData()` | `@/hooks`    | Dashboard data fetching                 |
-| `useAnalytics()`     | `@/hooks`    | @openpanel/nextjs analytics integration |
-| `useMediaQuery()`    | `@/hooks`    | Responsive breakpoint detection         |
+| Item                  | Import       | Exposes                                     |
+| --------------------- | ------------ | ------------------------------------------- |
+| `useAuthProjection()` | `@/contexts` | Typed `AuthState` and server-projected user |
+| `useAuth()`           | `@/contexts` | Legacy user, isAuthenticated, signOut       |
+| `useData()`           | `@/contexts` | vehicles, maintenance, CRUD methods         |
+| `useSupabase()`       | `@/contexts` | Raw Supabase client                         |
+| `useDashboardData()`  | `@/hooks`    | Dashboard data fetching                     |
+| `useAnalytics()`      | `@/hooks`    | @openpanel/nextjs analytics integration     |
+| `useMediaQuery()`     | `@/hooks`    | Responsive breakpoint detection             |
 
 ---
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,32 +1,19 @@
 "use client"
 
+import { useAuthProjection, useData } from "@/contexts"
 import { Dashboard } from "@/components/dashboard/Dashboard"
 import { LandingPage } from "@/components/home/LandingPage"
 import { Layout } from "@/components/layout/Layout"
-import { LoadingScreen } from "@/components/ui/loading-screen"
-import { useAuth, useData } from "@/contexts"
+import { AUTH_STATE_STATUS } from "@/lib/auth/contracts"
 
 export default function HomePage() {
-  const { user, profile, isLoading: authLoading } = useAuth()
+  const authState = useAuthProjection()
   const { vehicles, maintenanceRecords, scheduledServices, isLoading: dataLoading } = useData()
 
-  // Show loading screen only during initial auth check to prevent flash
-  const showLoadingScreen = authLoading
-
-  // Production ready - no debug logging
-
-  // Show loading screen during initial auth verification
-  if (showLoadingScreen) {
-    return <LoadingScreen message="Verificando autenticación..." />
-  }
-
-  // Renderizado condicional basado en autenticación
   return (
     <Layout showHeader={true}>
-      {user ? (
+      {authState.status === AUTH_STATE_STATUS.AUTHENTICATED ? (
         <Dashboard
-          user={user}
-          profile={profile}
           vehicles={vehicles}
           maintenanceRecords={maintenanceRecords}
           upcomingMaintenance={scheduledServices}

--- a/components/analytics/auth-analytics-adapter.tsx
+++ b/components/analytics/auth-analytics-adapter.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect } from "react"
+import { useAuthProjection } from "@/contexts/AuthProjectionContext"
+import { useAnalytics } from "@/hooks/use-analytics"
+import { AUTH_STATE_STATUS, type AuthState } from "@/lib/auth/contracts"
+
+interface AuthAnalyticsPort {
+  identifyUser(userId: string, properties: { email: string; firstName: string }): void
+  resetIdentification(): void
+}
+
+export function syncAuthAnalytics(authState: AuthState, analytics: AuthAnalyticsPort) {
+  if (authState.status === AUTH_STATE_STATUS.AUTHENTICATED) {
+    analytics.identifyUser(authState.user.id, {
+      email: authState.user.email ?? "",
+      firstName: authState.user.displayName,
+    })
+    return
+  }
+
+  analytics.resetIdentification()
+}
+
+export function AuthAnalyticsAdapter() {
+  const authState = useAuthProjection()
+  const { identifyUser, resetIdentification } = useAnalytics()
+
+  useEffect(() => {
+    syncAuthAnalytics(authState, { identifyUser, resetIdentification })
+  }, [authState, identifyUser, resetIdentification])
+
+  return null
+}

--- a/components/dashboard/Dashboard.tsx
+++ b/components/dashboard/Dashboard.tsx
@@ -25,18 +25,7 @@ interface Vehicle {
   updated_at: string
 }
 
-interface Profile {
-  id: string
-  full_name?: string
-  email: string
-}
-
 interface DashboardProps {
-  user: {
-    id: string
-    email?: string
-  }
-  profile: Profile | null
   vehicles: Vehicle[]
   maintenanceRecords: any[]
   upcomingMaintenance: ScheduledService[]

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -6,10 +6,10 @@ import Image from "next/image"
 import { useRouter } from "next/navigation"
 import { Car, User, LogOut, Plus, ChevronDown, Menu } from "lucide-react"
 
-import { useAuth, useData } from "@/contexts"
+import { useAuthProjection, useData } from "@/contexts"
 import { useAnalytics } from "@/hooks"
 import { LogoutControl } from "@/components/auth/logout-control"
-import { HeaderSkeleton } from "@/components/skeletons/header-skeleton"
+import { HeaderUserIdentity } from "@/components/layout/header-user-identity"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -20,9 +20,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger, SheetClose } from "@/components/ui/sheet"
+import { AUTH_STATE_STATUS } from "@/lib/auth/contracts"
 
 export function Header() {
-  const { user, profile, isLoading: authLoading } = useAuth()
+  const authState = useAuthProjection()
+  const user = authState.status === AUTH_STATE_STATUS.AUTHENTICATED ? authState.user : null
   const { vehicles } = useData()
   const { trackAuthAction } = useAnalytics()
   const [showVehiclesDropdown, setShowVehiclesDropdown] = useState(false)
@@ -36,11 +38,6 @@ export function Header() {
 
   const handleLogoutError = () => {
     trackAuthAction("error", "sign_out")
-  }
-
-  // Mostrar skeleton durante la carga inicial para evitar parpadeo
-  if (authLoading) {
-    return <HeaderSkeleton />
   }
 
   return (
@@ -58,8 +55,8 @@ export function Header() {
             {/* Desktop Navigation */}
             <div className="hidden items-center gap-3 lg:flex">
               {/* Saludo al usuario */}
-              <span className="text-muted-foreground text-sm">
-                Hola, {profile?.full_name || user.email?.split("@")[0]}
+              <span className="text-muted-foreground max-w-48 truncate text-sm" title={user.displayName}>
+                Hola, {user.displayName}
               </span>
 
               {/* Dropdown de Vehículos */}
@@ -126,10 +123,7 @@ export function Header() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-56">
                   <DropdownMenuLabel>
-                    <div className="flex flex-col space-y-1">
-                      <p className="text-sm leading-none font-medium">{profile?.full_name || "Usuario"}</p>
-                      <p className="text-muted-foreground text-xs leading-none">{user.email}</p>
-                    </div>
+                    <HeaderUserIdentity user={user} />
                   </DropdownMenuLabel>
 
                   <DropdownMenuSeparator />
@@ -172,10 +166,7 @@ export function Header() {
                       <div className="bg-primary/10 flex h-12 w-12 items-center justify-center rounded-full">
                         <User className="text-primary h-6 w-6" />
                       </div>
-                      <div className="flex flex-col">
-                        <p className="text-sm font-medium">{profile?.full_name || "Usuario"}</p>
-                        <p className="text-muted-foreground text-xs">{user.email}</p>
-                      </div>
+                      <HeaderUserIdentity user={user} />
                     </div>
 
                     {/* Vehicles Section */}

--- a/components/layout/header-user-identity.tsx
+++ b/components/layout/header-user-identity.tsx
@@ -1,0 +1,20 @@
+import type { CurrentUser } from "@/lib/auth/contracts"
+
+interface HeaderUserIdentityProps {
+  user: CurrentUser
+}
+
+export function HeaderUserIdentity({ user }: HeaderUserIdentityProps) {
+  return (
+    <div className="flex min-w-0 flex-col space-y-1">
+      <p className="truncate text-sm leading-none font-medium" title={user.displayName}>
+        {user.displayName}
+      </p>
+      {user.email ? (
+        <p className="text-muted-foreground truncate text-xs leading-none" title={user.email}>
+          {user.email}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/contexts/AppProviders.tsx
+++ b/contexts/AppProviders.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "./AuthContext"
 import { AuthProjectionProvider } from "./AuthProjectionContext"
 import { DataProvider } from "./DataContext"
 import { SupabaseProvider } from "./SupabaseContext"
+import { AuthAnalyticsAdapter } from "@/components/analytics/auth-analytics-adapter"
 import { ContextErrorBoundary } from "@/components/ui/context-error-boundary"
 import type { AuthState } from "@/lib/auth/contracts"
 
@@ -18,6 +19,7 @@ export function AppProviders({ children, initialAuthState }: AppProvidersProps) 
   return (
     <ContextErrorBoundary>
       <AuthProjectionProvider initialState={initialAuthState}>
+        <AuthAnalyticsAdapter />
         <SupabaseProvider>
           <AuthProvider>
             <DataProvider>

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -2,8 +2,7 @@
 
 /* eslint-disable no-console, react/jsx-no-constructed-context-values -- Auth failures are logged for diagnostics; context value memoization is deferred to avoid changing auth behavior. */
 
-import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from "react"
-import { useAnalytics } from "@/hooks/use-analytics"
+import React, { createContext, useContext, useEffect, useState } from "react"
 import { authManager } from "@/lib/auth/authManager"
 
 export interface AuthUser {
@@ -11,23 +10,15 @@ export interface AuthUser {
   email?: string
 }
 
-export interface Profile {
-  id: string
-  full_name?: string
-  email: string
-}
-
-interface AuthContextType {
+export interface AuthContextValue {
   user: AuthUser | null
-  profile: Profile | null
   isLoading: boolean
   isLoggingOut: boolean
   isAuthenticated: boolean
   signOut: () => Promise<void>
-  refreshProfile: () => Promise<void>
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined)
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
 
 interface AuthProviderProps {
   children: React.ReactNode
@@ -35,43 +26,8 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null)
-  const [profile, setProfile] = useState<Profile | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
-  const supabase = authManager.getSupabase()
-  const { identifyUser, trackAuthAction, resetIdentification } = useAnalytics()
-
-  // REFS para prevenir bucles infinitos con OpenPanel
-  const analyticsRef = useRef({ identifyUser, resetIdentification })
-  const isIdentifiedRef = useRef(false)
-
-  // Actualizar la ref cuando cambien las funciones de analytics
-  useEffect(() => {
-    analyticsRef.current = { identifyUser, resetIdentification }
-  }, [identifyUser, resetIdentification])
-
-  const loadProfile = useCallback(
-    async (userId: string) => {
-      try {
-        const { data, error } = await supabase.from("profiles").select("*").eq("id", userId).single()
-
-        if (error && error.code !== "PGRST116") {
-          console.error("Profile error:", error)
-        } else if (data) {
-          setProfile(data)
-        }
-      } catch (error) {
-        console.error("Profile load error:", error)
-      }
-    },
-    [supabase]
-  )
-
-  const refreshProfile = useCallback(async () => {
-    if (user?.id) {
-      await loadProfile(user.id)
-    }
-  }, [user?.id, loadProfile])
 
   useEffect(() => {
     // Suscribirse a cambios de estado del AuthManager
@@ -79,46 +35,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setIsLoading(state.isLoading)
 
       if (state.user) {
-        // Usuario autenticado
         setUser({
           id: state.user.id,
           email: state.user.email,
         })
-
-        // Crear perfil básico desde metadata
-        const basicProfile: Profile = {
-          id: state.user.id,
-          email: state.user.email || "",
-          full_name:
-            state.user.user_metadata?.name ||
-            state.user.user_metadata?.full_name ||
-            state.user.email?.split("@")[0] ||
-            "Usuario",
-        }
-        setProfile(basicProfile)
-
-        // Cargar perfil completo desde BD
-        loadProfile(state.user.id)
-
-        // Identify user in OpenPanel (solo una vez por sesión)
-        if (!isIdentifiedRef.current) {
-          isIdentifiedRef.current = true
-          analyticsRef.current.identifyUser(state.user.id, {
-            email: state.user.email || "",
-            firstName:
-              state.user.user_metadata?.name ||
-              state.user.user_metadata?.full_name ||
-              state.user.email?.split("@")[0] ||
-              "Usuario",
-          })
-        }
       } else {
-        // Usuario no autenticado
         setUser(null)
-        setProfile(null)
-        isIdentifiedRef.current = false
-        // Reset identification when user logs out
-        analyticsRef.current.resetIdentification()
       }
     })
 
@@ -126,7 +48,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return () => {
       unsubscribe()
     }
-  }, [loadProfile])
+  }, [])
 
   const signOut = async () => {
     // Prevenir múltiples intentos simultáneos
@@ -134,9 +56,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     try {
       setIsLoggingOut(true)
-
-      // Track sign out event
-      trackAuthAction("sign_out")
 
       // Usar AuthManager para cerrar sesión
       await authManager.signOut()
@@ -148,9 +67,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
     } catch (error) {
       console.error("Error durante sign out:", error)
 
-      // Track error
-      trackAuthAction("error", "sign_out")
-
       // Forzar redirección incluso si hay error
       if (typeof window !== "undefined") {
         window.location.href = `/auth/login?logout=${Date.now()}`
@@ -158,20 +74,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }
 
-  const value: AuthContextType = {
+  const value: AuthContextValue = {
     user,
-    profile,
     isLoading,
     isLoggingOut,
     isAuthenticated: !!user,
     signOut,
-    refreshProfile,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 
-export function useAuth(): AuthContextType {
+export function useAuth(): AuthContextValue {
   const context = useContext(AuthContext)
   if (context === undefined) {
     throw new Error("useAuth must be used within an AuthProvider")

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -6,6 +6,6 @@ export { DataProvider, useData } from "./DataContext"
 export { SupabaseProvider, useSupabase } from "./SupabaseContext"
 
 // Types
-export type { AuthUser, Profile } from "./AuthContext"
+export type { AuthContextValue, AuthUser } from "./AuthContext"
 
 export type { Vehicle, MaintenanceRecord, ScheduledService, ScheduledServiceStatus } from "./DataContext"

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -2,7 +2,7 @@
 
 /* eslint-disable no-console -- Auth hook logs failures until centralized observability is added. */
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect } from "react"
 import { useSupabase } from "@/hooks/useSupabase"
 
 interface AuthUser {
@@ -10,15 +10,8 @@ interface AuthUser {
   email?: string
 }
 
-interface Profile {
-  id: string
-  full_name?: string
-  email: string
-}
-
 interface AuthState {
   user: AuthUser | null
-  profile: Profile | null
   isLoading: boolean
   isAuthenticated: boolean
 }
@@ -27,26 +20,8 @@ export function useAuth(): AuthState & {
   signOut: () => Promise<void>
 } {
   const [user, setUser] = useState<AuthUser | null>(null)
-  const [profile, setProfile] = useState<Profile | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const supabase = useSupabase()
-
-  const loadProfile = useCallback(
-    async (userId: string) => {
-      try {
-        const { data, error } = await supabase.from("profiles").select("*").eq("id", userId).single()
-
-        if (error && error.code !== "PGRST116") {
-          console.error("Profile error:", error)
-        } else if (data) {
-          setProfile(data)
-        }
-      } catch (error) {
-        console.error("Profile load error:", error)
-      }
-    },
-    [supabase]
-  )
 
   useEffect(() => {
     let isMounted = true
@@ -65,36 +40,18 @@ export function useAuth(): AuthState & {
         if (authError) {
           console.error("Auth error:", authError)
           setUser(null)
-          setProfile(null)
           setIsLoading(false)
           return
         }
 
         if (authUser) {
           setUser({ id: authUser.id, email: authUser.email })
-
-          // Crear perfil básico
-          const basicProfile = {
-            id: authUser.id,
-            email: authUser.email || "",
-            full_name:
-              authUser.user_metadata?.name ||
-              authUser.user_metadata?.full_name ||
-              authUser.email?.split("@")[0] ||
-              "Usuario",
-          }
-          setProfile(basicProfile)
-
-          // Intentar cargar perfil de la base de datos
-          await loadProfile(authUser.id)
         } else {
           setUser(null)
-          setProfile(null)
         }
       } catch (error) {
         console.error("Error initializing auth:", error)
         setUser(null)
-        setProfile(null)
       } finally {
         if (isMounted) {
           setIsLoading(false)
@@ -121,22 +78,8 @@ export function useAuth(): AuthState & {
 
       if (event === "SIGNED_IN" && session?.user) {
         setUser({ id: session.user.id, email: session.user.email })
-
-        const basicProfile = {
-          id: session.user.id,
-          email: session.user.email || "",
-          full_name:
-            session.user.user_metadata?.name ||
-            session.user.user_metadata?.full_name ||
-            session.user.email?.split("@")[0] ||
-            "Usuario",
-        }
-        setProfile(basicProfile)
-
-        await loadProfile(session.user.id)
       } else if (event === "SIGNED_OUT") {
         setUser(null)
-        setProfile(null)
       }
     })
 
@@ -146,13 +89,12 @@ export function useAuth(): AuthState & {
       clearTimeout(safetyTimeout)
       subscription.unsubscribe()
     }
-  }, [supabase, loadProfile])
+  }, [supabase])
 
   const signOut = async () => {
     try {
       // 1. Clear local state
       setUser(null)
-      setProfile(null)
 
       // 2. Call server-side logout API to clear HTTP-only cookies
       const response = await fetch("/api/auth/signout", {
@@ -183,7 +125,6 @@ export function useAuth(): AuthState & {
     } catch (error) {
       console.error("Error during sign out:", error)
       setUser(null)
-      setProfile(null)
       if (typeof window !== "undefined") {
         window.location.href = "/"
       }
@@ -192,7 +133,6 @@ export function useAuth(): AuthState & {
 
   return {
     user,
-    profile,
     isLoading,
     isAuthenticated: !!user,
     signOut,

--- a/hooks/useDashboardData.tsx
+++ b/hooks/useDashboardData.tsx
@@ -28,12 +28,11 @@ interface DashboardData {
 
 export function useDashboardData(): DashboardData & {
   user: any
-  profile: any
   isLoading: boolean
   signOut: () => Promise<void>
   refreshData: () => Promise<void>
 } {
-  const { user, profile, isLoading: authLoading, signOut } = useAuth()
+  const { user, isLoading: authLoading, signOut } = useAuth()
   const [vehicles, setVehicles] = useState<Vehicle[]>([])
   const [maintenanceRecords, setMaintenanceRecords] = useState<any[]>([])
   const [upcomingMaintenance, setUpcomingMaintenance] = useState<ScheduledService[]>([])
@@ -178,7 +177,6 @@ export function useDashboardData(): DashboardData & {
 
   return {
     user,
-    profile,
     vehicles,
     maintenanceRecords,
     upcomingMaintenance,

--- a/tests/integration/auth/identity-adapters.test.ts
+++ b/tests/integration/auth/identity-adapters.test.ts
@@ -1,0 +1,66 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { syncAuthAnalytics } from "@/components/analytics/auth-analytics-adapter"
+import { HeaderUserIdentity } from "@/components/layout/header-user-identity"
+import { AUTH_STATE_STATUS, type CurrentUser, type UserId } from "@/lib/auth/contracts"
+
+const currentUser: CurrentUser = {
+  id: "user-1" as UserId,
+  email: "driver@example.com",
+  displayName: "Ada Driver",
+}
+
+describe("auth identity adapters", () => {
+  it("renders email and visible name from the server-projected CurrentUser", () => {
+    const markup = renderToStaticMarkup(createElement(HeaderUserIdentity, { user: currentUser }))
+
+    expect(markup).toContain("Ada Driver")
+    expect(markup).toContain("driver@example.com")
+  })
+
+  it("identifies the authenticated projection through an external analytics adapter", () => {
+    const events: unknown[] = []
+
+    syncAuthAnalytics(
+      { status: AUTH_STATE_STATUS.AUTHENTICATED, user: currentUser },
+      {
+        identifyUser(userId, properties) {
+          events.push(["identify", userId, properties])
+        },
+        resetIdentification() {
+          events.push(["reset"])
+        },
+      }
+    )
+
+    expect(events).toEqual([
+      [
+        "identify",
+        "user-1",
+        {
+          email: "driver@example.com",
+          firstName: "Ada Driver",
+        },
+      ],
+    ])
+  })
+
+  it("resets analytics identity when the server projection becomes anonymous", () => {
+    const events: string[] = []
+
+    syncAuthAnalytics(
+      { status: AUTH_STATE_STATUS.ANONYMOUS, user: null },
+      {
+        identifyUser() {
+          events.push("identify")
+        },
+        resetIdentification() {
+          events.push("reset")
+        },
+      }
+    )
+
+    expect(events).toEqual(["reset"])
+  })
+})

--- a/tests/unit/auth/client-contract.test.ts
+++ b/tests/unit/auth/client-contract.test.ts
@@ -1,0 +1,11 @@
+import { describe, expectTypeOf, it } from "vitest"
+import type { AuthContextValue } from "@/contexts/AuthContext"
+import type { useAuth as useLegacyAuth } from "@/hooks/useAuth"
+
+describe("client authentication contract", () => {
+  it("keeps profile loading and updates outside the public auth interface", () => {
+    expectTypeOf<AuthContextValue>().not.toHaveProperty("profile")
+    expectTypeOf<AuthContextValue>().not.toHaveProperty("refreshProfile")
+    expectTypeOf<ReturnType<typeof useLegacyAuth>>().not.toHaveProperty("profile")
+  })
+})


### PR DESCRIPTION
## What changed

- Move the header and home shell to the server-seeded `AuthState` / `CurrentUser` projection.
- Remove profile loading and profile fields from the public authentication contracts and compatibility hook.
- Move analytics identity synchronization to an external adapter that observes the auth projection.
- Add contract and integration coverage for visible identity and analytics transitions.
- Update `AGENTS.md` to document the incremental auth projection boundary.

## Why

Ticket #47 requires visible identity to come exclusively from `CurrentUser`, keeps profile concerns outside authentication, and prevents the auth core from importing analytics hooks or SDKs.

## Validation

- `bun lint`
- `bun fmt:check`
- `bun run test` — 99 tests passed
- `bun type-check`
- `bun run build`
- Local anonymous shell and 320px responsive browser check