### PR TITLE
feat(auth): synchronize tabs through invalidation

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -2,6 +2,7 @@
 
 import type { NextRequest } from "next/server"
 import { NextResponse } from "next/server"
+import { AUTH_INVALIDATION_SEARCH_PARAM } from "@/lib/auth/auth-invalidation"
 import { OAUTH_ERROR_CODE } from "@/lib/auth/contracts"
 import { createOAuthErrorRedirect, sanitizeInternalRedirect } from "@/lib/auth/redirects"
 import { createClient } from "@/lib/supabase/server"
@@ -46,7 +47,10 @@ export function createAuthCallbackHandler(createAdapter: AuthCallbackAdapterFact
         return NextResponse.redirect(createOAuthErrorRedirect(origin, OAUTH_ERROR_CODE.PROVIDER_ERROR))
       }
 
-      return NextResponse.redirect(new URL(next, origin))
+      const destination = new URL(next, origin)
+      destination.searchParams.set(AUTH_INVALIDATION_SEARCH_PARAM, "1")
+
+      return NextResponse.redirect(destination)
     } catch (error) {
       console.error("Auth callback error:", error)
       const { origin } = new URL(request.url)

--- a/components/auth/password-login-form.tsx
+++ b/components/auth/password-login-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useAuthProjectionInvalidation } from "@/contexts"
 import { useAnalytics } from "@/hooks/use-analytics"
 import { GoogleSignInButton } from "./google-signin-button"
 import { PasswordLoginFeedback } from "./password-login-feedback"
@@ -20,6 +21,7 @@ interface PasswordLoginFormProps {
 
 export function PasswordLoginForm({ redirectTo }: PasswordLoginFormProps) {
   const router = useRouter()
+  const invalidateProjection = useAuthProjectionInvalidation()
   const { trackAuthAction } = useAnalytics()
   const [result, formAction, isPending] = useActionState(
     (previousResult: PasswordLoginResult | null, formData: FormData) =>
@@ -33,6 +35,7 @@ export function PasswordLoginForm({ redirectTo }: PasswordLoginFormProps) {
         },
         onSuccess(destination) {
           trackAuthAction("sign_in", "email")
+          invalidateProjection()
           router.replace(destination)
           router.refresh()
         },

--- a/components/auth/signup-form.tsx
+++ b/components/auth/signup-form.tsx
@@ -6,17 +6,20 @@ import { signupAction } from "@/app/auth/actions"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useAuthProjectionInvalidation } from "@/contexts"
 import { SignupFeedback } from "./signup-feedback"
 import { SIGN_UP_STATUS, type SignUpResult } from "@/lib/auth/contracts"
 import { runSignupFormAction } from "./signup-form-action"
 
 export function SignupForm() {
   const router = useRouter()
+  const invalidateProjection = useAuthProjectionInvalidation()
   const [result, formAction, isPending] = useActionState(
     (previousResult: SignUpResult | null, formData: FormData) =>
       runSignupFormAction(previousResult, formData, {
         signupAction,
         onAuthenticated(destination) {
+          invalidateProjection()
           router.replace(destination)
           router.refresh()
         },

--- a/contexts/AppProviders.tsx
+++ b/contexts/AppProviders.tsx
@@ -2,8 +2,7 @@
 
 import React from "react"
 import { Toaster } from "sonner"
-import { AuthProvider } from "./AuthContext"
-import { AuthProjectionProvider } from "./AuthProjectionContext"
+import { AuthProjectionProvider, AuthProjectionSynchronization } from "./AuthProjectionContext"
 import { DataProvider } from "./DataContext"
 import { SupabaseProvider } from "./SupabaseContext"
 import { AuthAnalyticsAdapter } from "@/components/analytics/auth-analytics-adapter"
@@ -19,15 +18,15 @@ export function AppProviders({ children, initialAuthState }: AppProvidersProps) 
   return (
     <ContextErrorBoundary>
       <AuthProjectionProvider initialState={initialAuthState}>
-        <AuthAnalyticsAdapter />
-        <SupabaseProvider>
-          <AuthProvider>
+        <AuthProjectionSynchronization>
+          <AuthAnalyticsAdapter />
+          <SupabaseProvider>
             <DataProvider>
               {children}
               <Toaster />
             </DataProvider>
-          </AuthProvider>
-        </SupabaseProvider>
+          </SupabaseProvider>
+        </AuthProjectionSynchronization>
       </AuthProjectionProvider>
     </ContextErrorBoundary>
   )

--- a/contexts/AuthProjectionContext.tsx
+++ b/contexts/AuthProjectionContext.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react"
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import {
+  AUTH_INVALIDATION_SEARCH_PARAM,
+  createAuthInvalidationCoordinator,
+  createBrowserAuthInvalidationChannel,
+} from "@/lib/auth/auth-invalidation"
 import { AUTH_STATE_STATUS, type AuthState } from "@/lib/auth/contracts"
 
 const AuthProjectionContext = createContext<AuthState | null>(null)
@@ -25,6 +31,81 @@ export function AuthProjectionProvider({ children, initialState }: AuthProjectio
   return (
     <AuthProjectionInvalidationContext.Provider value={invalidate}>
       <AuthProjectionContext.Provider value={state}>{children}</AuthProjectionContext.Provider>
+    </AuthProjectionInvalidationContext.Provider>
+  )
+}
+
+export function AuthProjectionSynchronization({ children }: { children?: ReactNode }) {
+  const invalidateLocalProjection = useAuthProjectionInvalidation()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const serializedSearchParams = searchParams.toString()
+  const navigationKey = serializedSearchParams ? `${pathname}?${serializedSearchParams}` : pathname
+  const hasAuthInvalidation = searchParams.get(AUTH_INVALIDATION_SEARCH_PARAM) === "1"
+  const coordinatorRef = useRef<ReturnType<typeof createAuthInvalidationCoordinator> | null>(null)
+  const previousNavigationRef = useRef(navigationKey)
+  const handledAuthRedirectRef = useRef(false)
+
+  useEffect(() => {
+    const coordinator = createAuthInvalidationCoordinator({
+      channel: createBrowserAuthInvalidationChannel(),
+      invalidateProjection: invalidateLocalProjection,
+      refreshNavigation() {
+        router.refresh()
+      },
+    })
+    const revalidateOnFocus = () => coordinator.revalidate()
+
+    coordinatorRef.current = coordinator
+    window.addEventListener("focus", revalidateOnFocus)
+
+    return () => {
+      window.removeEventListener("focus", revalidateOnFocus)
+      coordinator.dispose()
+
+      if (coordinatorRef.current === coordinator) {
+        coordinatorRef.current = null
+      }
+    }
+  }, [invalidateLocalProjection, router])
+
+  useEffect(() => {
+    if (previousNavigationRef.current === navigationKey) {
+      return
+    }
+
+    previousNavigationRef.current = navigationKey
+    coordinatorRef.current?.revalidate()
+  }, [navigationKey])
+
+  useEffect(() => {
+    if (!hasAuthInvalidation || handledAuthRedirectRef.current) {
+      return
+    }
+
+    handledAuthRedirectRef.current = true
+    coordinatorRef.current?.publish()
+
+    const nextSearchParams = new URLSearchParams(serializedSearchParams)
+    nextSearchParams.delete(AUTH_INVALIDATION_SEARCH_PARAM)
+    const nextQuery = nextSearchParams.size > 0 ? `?${nextSearchParams.toString()}` : ""
+    router.replace(`${pathname}${nextQuery}${window.location.hash}`, { scroll: false })
+  }, [hasAuthInvalidation, pathname, router, serializedSearchParams])
+
+  const invalidate = useCallback(() => {
+    const coordinator = coordinatorRef.current
+
+    if (coordinator) {
+      coordinator.invalidate()
+    } else {
+      invalidateLocalProjection()
+    }
+  }, [invalidateLocalProjection])
+
+  return (
+    <AuthProjectionInvalidationContext.Provider value={invalidate}>
+      {children}
     </AuthProjectionInvalidationContext.Provider>
   )
 }

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,11 +1,13 @@
 // Context exports
 export { AppProviders } from "./AppProviders"
-export { AuthProvider, useAuth } from "./AuthContext"
-export { AuthProjectionProvider, useAuthProjection, useAuthProjectionInvalidation } from "./AuthProjectionContext"
+export {
+  AuthProjectionProvider,
+  AuthProjectionSynchronization,
+  useAuthProjection,
+  useAuthProjectionInvalidation,
+} from "./AuthProjectionContext"
 export { DataProvider, useData } from "./DataContext"
 export { SupabaseProvider, useSupabase } from "./SupabaseContext"
 
 // Types
-export type { AuthContextValue, AuthUser } from "./AuthContext"
-
 export type { Vehicle, MaintenanceRecord, ScheduledService, ScheduledServiceStatus } from "./DataContext"

--- a/lib/auth/auth-invalidation.ts
+++ b/lib/auth/auth-invalidation.ts
@@ -1,0 +1,88 @@
+/* eslint-disable unicorn/require-post-message-target-origin -- BroadcastChannel messages stay within the named same-origin channel. */
+
+export const AUTH_INVALIDATION_EVENT = Object.freeze({ type: "auth-invalidated" as const })
+export const AUTH_INVALIDATION_CHANNEL_NAME = "keepel-auth-invalidation"
+export const AUTH_INVALIDATION_SEARCH_PARAM = "keepel-auth-invalidated"
+
+export interface AuthInvalidationChannel {
+  postMessage(message: typeof AUTH_INVALIDATION_EVENT): void
+  subscribe(listener: (message: unknown) => void): () => void
+  close(): void
+}
+
+export function createBrowserAuthInvalidationChannel(): AuthInvalidationChannel | null {
+  if (typeof window === "undefined" || typeof window.BroadcastChannel !== "function") {
+    return null
+  }
+
+  let channel: BroadcastChannel
+
+  try {
+    channel = new window.BroadcastChannel(AUTH_INVALIDATION_CHANNEL_NAME)
+  } catch {
+    return null
+  }
+
+  return {
+    postMessage(message) {
+      channel.postMessage(message)
+    },
+    subscribe(listener) {
+      const handleMessage = (event: MessageEvent<unknown>) => listener(event.data)
+      channel.addEventListener("message", handleMessage)
+
+      return () => channel.removeEventListener("message", handleMessage)
+    },
+    close() {
+      channel.close()
+    },
+  }
+}
+
+interface AuthInvalidationCoordinatorDependencies {
+  channel: AuthInvalidationChannel | null
+  invalidateProjection(): void
+  refreshNavigation(): void
+}
+
+function isAuthInvalidationEvent(message: unknown): message is typeof AUTH_INVALIDATION_EVENT {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return false
+  }
+
+  const record = message as Record<string, unknown>
+
+  return Object.keys(record).length === 1 && record.type === AUTH_INVALIDATION_EVENT.type
+}
+
+export function createAuthInvalidationCoordinator({
+  channel,
+  invalidateProjection,
+  refreshNavigation,
+}: AuthInvalidationCoordinatorDependencies) {
+  const unsubscribe = channel?.subscribe((message) => {
+    if (!isAuthInvalidationEvent(message)) {
+      return
+    }
+
+    invalidateProjection()
+    refreshNavigation()
+  })
+
+  return {
+    publish() {
+      channel?.postMessage(AUTH_INVALIDATION_EVENT)
+    },
+    invalidate() {
+      invalidateProjection()
+      channel?.postMessage(AUTH_INVALIDATION_EVENT)
+    },
+    revalidate() {
+      refreshNavigation()
+    },
+    dispose() {
+      unsubscribe?.()
+      channel?.close()
+    },
+  }
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -62,8 +62,15 @@ export function createClient() {
           document.cookie = cookie
         },
       },
+      auth: {
+        skipAutoInitialize: true,
+      },
+      isSingleton: false,
     }
   )
+
+  // Data requests read the SSR session lazily; Supabase's auth channel must not broadcast that session.
+  void supabaseClient.auth.dispose()
 
   return supabaseClient
 }

--- a/tests/integration/auth/browser-data-client.test.ts
+++ b/tests/integration/auth/browser-data-client.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+class RecordingBroadcastChannel extends EventTarget {
+  static instances: RecordingBroadcastChannel[] = []
+  readonly messages: unknown[] = []
+  closed = false
+
+  constructor(readonly name: string) {
+    super()
+    RecordingBroadcastChannel.instances.push(this)
+  }
+
+  postMessage(message: unknown) {
+    this.messages.push(message)
+  }
+
+  close() {
+    this.closed = true
+  }
+}
+
+describe("browser data client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    RecordingBroadcastChannel.instances = []
+  })
+
+  it("closes Supabase's session channel before browser data access", async () => {
+    vi.stubGlobal("BroadcastChannel", RecordingBroadcastChannel)
+    vi.stubGlobal("window", globalThis)
+    vi.stubGlobal("document", { cookie: "" })
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://keepel-test.supabase.co")
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key")
+    vi.resetModules()
+    const { createClient } = await import("@/lib/supabase/client")
+
+    createClient()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(RecordingBroadcastChannel.instances).toHaveLength(1)
+    expect(RecordingBroadcastChannel.instances[0]).toMatchObject({
+      name: "sb-keepel-test-auth-token",
+      closed: true,
+      messages: [],
+    })
+  })
+})

--- a/tests/integration/auth/callback.test.ts
+++ b/tests/integration/auth/callback.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server"
 import { describe, expect, it } from "vitest"
 import { createAuthCallbackHandler } from "@/app/auth/callback/route"
+import { AUTH_INVALIDATION_SEARCH_PARAM } from "@/lib/auth/auth-invalidation"
 import { createControlledAuthCallbackAdapter } from "@/tests/support/controlled-auth-callback-adapter"
 
 describe("auth callback", () => {
@@ -16,8 +17,13 @@ describe("auth callback", () => {
     )
 
     const response = await handleCallback(request)
+    const redirect = new URL(response.headers.get("location") ?? "")
 
-    expect(response.headers.get("location")).toBe(`https://keepel.example${destination}`)
+    expect(redirect.origin).toBe("https://keepel.example")
+    expect(redirect.pathname).toBe("/vehicles/vehicle-1/maintenance")
+    expect(redirect.searchParams.get("status")).toBe("due")
+    expect(redirect.searchParams.get(AUTH_INVALIDATION_SEARCH_PARAM)).toBe("1")
+    expect(redirect.hash).toBe("#record-42")
   })
 
   it("uses the application root when the return destination is external", async () => {
@@ -31,8 +37,11 @@ describe("auth callback", () => {
     )
 
     const response = await handleCallback(request)
+    const redirect = new URL(response.headers.get("location") ?? "")
 
-    expect(response.headers.get("location")).toBe("https://keepel.example/")
+    expect(redirect.origin).toBe("https://keepel.example")
+    expect(redirect.pathname).toBe("/")
+    expect(Array.from(redirect.searchParams)).toEqual([[AUTH_INVALIDATION_SEARCH_PARAM, "1"]])
   })
 
   it("maps provider cancellation to a stable browser-visible error", async () => {

--- a/tests/integration/auth/cross-tab-invalidation.test.ts
+++ b/tests/integration/auth/cross-tab-invalidation.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest"
+import { runLogoutFormAction } from "@/components/auth/logout-form-action"
+import { runPasswordLoginFormAction } from "@/components/auth/password-login-form-action"
+import {
+  AUTH_INVALIDATION_EVENT,
+  createAuthInvalidationCoordinator,
+  type AuthInvalidationChannel,
+} from "@/lib/auth/auth-invalidation"
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE } from "@/lib/auth/contracts"
+import { createSessionExpiredRecovery } from "@/lib/auth/session-expiry-recovery"
+
+function createTwoTabChannelHub() {
+  const listeners = [new Set<(message: unknown) => void>(), new Set<(message: unknown) => void>()]
+  const messages: unknown[] = []
+
+  function createChannel(tabIndex: number): AuthInvalidationChannel {
+    return {
+      postMessage(message) {
+        messages.push(message)
+
+        for (const [index, tabListeners] of listeners.entries()) {
+          if (index !== tabIndex) {
+            tabListeners.forEach((listener) => listener(message))
+          }
+        }
+      },
+      subscribe(listener) {
+        listeners[tabIndex].add(listener)
+
+        return () => listeners[tabIndex].delete(listener)
+      },
+      close() {
+        listeners[tabIndex].clear()
+      },
+    }
+  }
+
+  return { createChannel, messages }
+}
+
+function createTwoTabs() {
+  const hub = createTwoTabChannelHub()
+  const senderEvents: string[] = []
+  const receiverEvents: string[] = []
+  const sender = createAuthInvalidationCoordinator({
+    channel: hub.createChannel(0),
+    invalidateProjection() {
+      senderEvents.push("invalidate")
+    },
+    refreshNavigation() {
+      senderEvents.push("refresh")
+    },
+  })
+  const receiver = createAuthInvalidationCoordinator({
+    channel: hub.createChannel(1),
+    invalidateProjection() {
+      receiverEvents.push("invalidate")
+    },
+    refreshNavigation() {
+      receiverEvents.push("refresh")
+    },
+  })
+
+  return {
+    hub,
+    sender,
+    senderEvents,
+    receiverEvents,
+    dispose() {
+      sender.dispose()
+      receiver.dispose()
+    },
+  }
+}
+
+describe("cross-tab authentication invalidation", () => {
+  it("publishes only a semantic event after login and revalidates the receiving tab", async () => {
+    const tabs = createTwoTabs()
+    const formData = new FormData()
+    formData.set("email", "driver@example.com")
+    formData.set("password", "secret-password")
+
+    await runPasswordLoginFormAction(null, formData, {
+      loginAction: vi.fn(async () => ({
+        status: AUTH_COMMAND_STATUS.SUCCESS,
+        data: { redirectTo: "/" },
+      })),
+      onAttempt() {},
+      onError() {},
+      onSuccess() {
+        tabs.sender.invalidate()
+      },
+    })
+
+    expect(tabs.hub.messages).toEqual([AUTH_INVALIDATION_EVENT])
+    expect(Object.keys(tabs.hub.messages[0] as object)).toEqual(["type"])
+    expect(JSON.stringify(tabs.hub.messages)).not.toMatch(/user|profile|session|token/i)
+    expect(tabs.senderEvents).toEqual(["invalidate"])
+    expect(tabs.receiverEvents).toEqual(["invalidate", "refresh"])
+
+    tabs.dispose()
+  })
+
+  it("publishes an OAuth callback invalidation without clearing the server-confirmed sender", () => {
+    const tabs = createTwoTabs()
+
+    tabs.sender.publish()
+
+    expect(tabs.hub.messages).toEqual([AUTH_INVALIDATION_EVENT])
+    expect(tabs.senderEvents).toEqual([])
+    expect(tabs.receiverEvents).toEqual(["invalidate", "refresh"])
+
+    tabs.dispose()
+  })
+
+  it("invalidates and revalidates a second tab after logout", async () => {
+    const tabs = createTwoTabs()
+
+    await runLogoutFormAction(null, new FormData(), {
+      logoutAction: vi.fn(async () => ({ status: AUTH_COMMAND_STATUS.SUCCESS, data: null })),
+      onAttempt() {},
+      onError() {},
+      onSuccess() {
+        tabs.sender.invalidate()
+      },
+    })
+
+    expect(tabs.hub.messages).toEqual([AUTH_INVALIDATION_EVENT])
+    expect(tabs.senderEvents).toEqual(["invalidate"])
+    expect(tabs.receiverEvents).toEqual(["invalidate", "refresh"])
+
+    tabs.dispose()
+  })
+
+  it("invalidates and revalidates a second tab after session expiry", () => {
+    const tabs = createTwoTabs()
+    const recoverSession = createSessionExpiredRecovery({
+      invalidateProjection: tabs.sender.invalidate,
+      navigate(destination) {
+        tabs.senderEvents.push(`navigate:${destination}`)
+      },
+      refreshNavigation: tabs.sender.revalidate,
+    })
+
+    const recovered = recoverSession(
+      {
+        status: AUTH_COMMAND_STATUS.ERROR,
+        error: { code: AUTH_ERROR_CODE.SESSION_EXPIRED },
+      },
+      "/vehicles/vehicle-1"
+    )
+
+    expect(recovered).toBe(true)
+    expect(tabs.hub.messages).toEqual([AUTH_INVALIDATION_EVENT])
+    expect(tabs.senderEvents).toEqual([
+      "invalidate",
+      "navigate:/auth/login?redirect=%2Fvehicles%2Fvehicle-1",
+      "refresh",
+    ])
+    expect(tabs.receiverEvents).toEqual(["invalidate", "refresh"])
+
+    tabs.dispose()
+  })
+
+  it("revalidates focus and navigation fallbacks without clearing or broadcasting", () => {
+    const hub = createTwoTabChannelHub()
+    const events: string[] = []
+    const tab = createAuthInvalidationCoordinator({
+      channel: hub.createChannel(0),
+      invalidateProjection() {
+        events.push("invalidate")
+      },
+      refreshNavigation() {
+        events.push("refresh")
+      },
+    })
+
+    tab.revalidate()
+    tab.revalidate()
+
+    expect(events).toEqual(["refresh", "refresh"])
+    expect(hub.messages).toEqual([])
+
+    tab.dispose()
+  })
+
+  it("ignores malformed or payload-bearing messages", () => {
+    const hub = createTwoTabChannelHub()
+    const senderChannel = hub.createChannel(0)
+    const receiverEvents: string[] = []
+    const receiver = createAuthInvalidationCoordinator({
+      channel: hub.createChannel(1),
+      invalidateProjection() {
+        receiverEvents.push("invalidate")
+      },
+      refreshNavigation() {
+        receiverEvents.push("refresh")
+      },
+    })
+    const sendUntrustedMessage = senderChannel.postMessage as (message: unknown) => void
+
+    sendUntrustedMessage({ type: AUTH_INVALIDATION_EVENT.type, session: { accessToken: "secret" } })
+    sendUntrustedMessage({ type: "AUTH_STATE_CHANGE", state: { user: { email: "driver@example.com" } } })
+
+    expect(receiverEvents).toEqual([])
+
+    senderChannel.close()
+    receiver.dispose()
+  })
+})

--- a/tests/integration/auth/google-oauth-flow.test.ts
+++ b/tests/integration/auth/google-oauth-flow.test.ts
@@ -137,7 +137,9 @@ describe("Google OAuth flow", () => {
 
     const response = await handleCallback(request)
 
-    expect(response.headers.get("location")).toBe("https://keepel.example/vehicles?filter=due")
+    expect(response.headers.get("location")).toBe(
+      "https://keepel.example/vehicles?filter=due&keepel-auth-invalidated=1"
+    )
     expect(Array.from(serverCookies.values.keys())).toContainEqual(expect.stringMatching(/^sb-keepel-test-auth-token$/))
     expect(response.headers.get("location")).not.toMatch(/access.?token|refresh.?token|session/i)
     expect(await response.text()).toBe("")


### PR DESCRIPTION
## Summary

Synchronizes authentication changes across tabs through semantic invalidation events while keeping server state authoritative. Receiving tabs clear their local projection and refresh navigation without exchanging users, profiles, sessions, or tokens.

## Changes

- **Auth invalidation boundary**: adds a validated one-field BroadcastChannel event and deterministic coordinator for publish, invalidate, revalidate, and cleanup behavior.
- **React projection synchronization**: publishes login, signup, logout, expiry, and OAuth changes; revalidates on received events, focus, pathname changes, and query changes.
- **Sensitive channel removal**: unmounts the legacy auth provider and closes the Supabase data client session channel before lazy browser data access.
- **OAuth callback bridge**: adds and consumes a one-time semantic redirect marker without exposing session state.
- **Regression coverage**: adds deterministic two-tab tests for login, logout, expiry, OAuth, malformed payloads, fallback revalidation, and Supabase channel shutdown.

## Testing

- `bun run test` (112 tests)
- `bun run type-check`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`

## Related Issues

Closes #49