### PR TITLE
test(auth): verify browser authentication lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 # production
 /build
 
+# playwright
+/playwright-report/
+/test-results/
+/blob-report/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ This project uses the following technologies. Agents should understand these reg
 bun dev              # Development server
 bun build            # Production build
 bun start            # Start production build
+bun run test          # Unit and integration tests
+bun run test:e2e      # Playwright browser tests
 bun lint             # oxlint
 bun type-check       # TypeScript check without emitting
 bun format           # oxfmt format

--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "zod": "3.25.67",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.0",
         "@types/node": "^22.19.21",
         "@types/react": "^19.2.17",
@@ -354,6 +355,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.69.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.69.0", "", { "os": "win32", "cpu": "x64" }, "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.0", "", {}, "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="],
 
@@ -833,6 +836,10 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
@@ -1076,6 +1083,8 @@
     "cmdk/@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "optionalDependencies": { "@types/react": "19.2.7" }, "peerDependencies": { "react": "19.2.3" } }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "optionalDependencies": { "@types/react": "19.2.7", "@types/react-dom": "19.2.3" }, "peerDependencies": { "react": "19.2.3", "react-dom": "19.2.3" } }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "react-remove-scroll/@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -114,7 +114,12 @@ export function Header() {
               {/* Dropdown del usuario */}
               <DropdownMenu modal={false} open={showUserDropdown} onOpenChange={setShowUserDropdown}>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="hover:bg-accent flex cursor-pointer items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Abrir menú de usuario"
+                    className="hover:bg-accent flex cursor-pointer items-center gap-2"
+                  >
                     <div className="bg-primary/10 flex h-8 w-8 items-center justify-center rounded-full">
                       <User className="text-primary h-4 w-4" />
                     </div>

--- a/docs/manual-testing/google-oauth.md
+++ b/docs/manual-testing/google-oauth.md
@@ -1,6 +1,6 @@
 # Google OAuth manual verification
 
-The automated auth integration tests cover Keepel's server initiation, PKCE callback exchange, cancellation, and stable error mapping. The Google consent screen itself requires this manual check against a configured Supabase project.
+The automated auth integration and Playwright browser tests cover Keepel's server initiation, controlled PKCE callback exchange, cancellation, stable error mapping, and authenticated UI return. Run them with `bun run test` and `bun run test:e2e`. The real Google consent screen itself requires this manual check against a configured Supabase project.
 
 ## Prerequisites
 

--- a/lib/auth/session-expiry-recovery.ts
+++ b/lib/auth/session-expiry-recovery.ts
@@ -20,8 +20,8 @@ export function createSessionExpiredRecovery({
     const searchParams = new URLSearchParams({ redirect: sanitizeInternalRedirect(returnTo) })
 
     invalidateProjection()
-    navigate(`/auth/login?${searchParams.toString()}`)
     refreshNavigation()
+    navigate(`/auth/login?${searchParams.toString()}`)
 
     return true
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "clean": "bun dlx rimraf .next out node_modules/.cache",
@@ -82,6 +83,7 @@
     "zod": "3.25.67"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^22.19.21",
     "@types/react": "^19.2.17",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test"
+import { APP_URL, CONTROLLED_SERVICES_URL } from "./tests/e2e/support/controlled-services-config"
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: APP_URL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: "bun tests/e2e/support/controlled-services.ts",
+      url: `${CONTROLLED_SERVICES_URL}/health`,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: "bun run dev --hostname 127.0.0.1 --port 3100",
+      url: APP_URL,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        NEXT_PUBLIC_SUPABASE_URL: CONTROLLED_SERVICES_URL,
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: "e2e-anon-key",
+        NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL: `${APP_URL}/`,
+        UPSTASH_REDIS_REST_URL: CONTROLLED_SERVICES_URL,
+        UPSTASH_REDIS_REST_TOKEN: "e2e-redis-token",
+      },
+    },
+  ],
+})

--- a/tests/e2e/auth/google-oauth.spec.ts
+++ b/tests/e2e/auth/google-oauth.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test"
+import { resetControlledServices } from "../support/controlled-services-config"
+
+test("Google OAuth returns through the PKCE callback to authenticated UI", async ({ page, request }) => {
+  await resetControlledServices(request, "success")
+  await page.goto("/auth/login?redirect=%2Fvehicles")
+
+  await page.getByRole("link", { name: "Continuar con Google" }).click()
+
+  await expect(page).toHaveURL(/\/vehicles$/)
+  await expect(page.getByRole("banner").getByText("Hola, Ada Driver", { exact: true })).toBeVisible()
+  expect(page.url()).not.toContain("code=")
+  expect(page.url()).not.toContain("access_token")
+})
+
+test("Google OAuth cancellation maps to a stable public error", async ({ page, request }) => {
+  await resetControlledServices(request, "cancel")
+  await page.goto("/auth/login")
+
+  await page.getByRole("link", { name: "Continuar con Google" }).click()
+
+  await expect(page).toHaveURL(/\/auth\/error\?error=oauth_cancelled$/)
+  await expect(page.getByText("Código de error: oauth_cancelled", { exact: true })).toBeVisible()
+  await expect(page.getByText(/controlled provider description/i)).toHaveCount(0)
+})
+
+test("Google OAuth exchange failures hide provider details", async ({ page, request }) => {
+  await resetControlledServices(request, "exchange_error")
+  await page.goto("/auth/login")
+
+  await page.getByRole("link", { name: "Continuar con Google" }).click()
+
+  await expect(page).toHaveURL(/\/auth\/error\?error=provider_error$/)
+  await expect(page.getByText("Código de error: provider_error", { exact: true })).toBeVisible()
+  expect(page.url()).not.toContain("controlled-provider-secret")
+  await expect(page.getByText(/controlled-provider-secret/i)).toHaveCount(0)
+})

--- a/tests/e2e/auth/password-and-signup.spec.ts
+++ b/tests/e2e/auth/password-and-signup.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test"
+import { resetControlledServices } from "../support/controlled-services-config"
+
+test.beforeEach(async ({ request }) => {
+  await resetControlledServices(request)
+})
+
+test("a user can sign in with a password and continue to a protected route", async ({ page }) => {
+  await page.goto("/auth/login?redirect=%2Fvehicles")
+  await page.getByLabel("Email").fill("driver@keepel.test")
+  await page.getByLabel("Contraseña").fill("correct-horse")
+  await page.getByRole("button", { name: "Iniciar Sesión", exact: true }).click()
+
+  await expect(page).toHaveURL(/\/vehicles$/)
+  await expect(page.getByText("Hola, Ada Driver", { exact: true })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Mis Vehículos" })).toBeVisible()
+})
+
+test("invalid password credentials show stable user-facing feedback", async ({ page }) => {
+  await page.goto("/auth/login")
+  await page.getByLabel("Email").fill("driver@keepel.test")
+  await page.getByLabel("Contraseña").fill("incorrect-password")
+  await page.getByRole("button", { name: "Iniciar Sesión", exact: true }).click()
+
+  await expect(page.getByText("El email o la contraseña no son correctos.", { exact: true })).toBeVisible()
+  await expect(page).toHaveURL(/\/auth\/login$/)
+})
+
+test("signup requiring email confirmation leads to the confirmation instructions", async ({ page }) => {
+  await page.goto("/auth/signup")
+  await page.getByLabel("Nombre Completo").fill("Grace Mechanic")
+  await page.getByLabel("Email").fill("grace@keepel.test")
+  await page.getByLabel("Contraseña", { exact: true }).fill("correct-horse")
+  await page.getByLabel("Confirmar Contraseña").fill("correct-horse")
+  await page.getByRole("button", { name: "Crear Cuenta", exact: true }).click()
+
+  await expect(page).toHaveURL(/\/auth\/signup-success$/)
+  await expect(page.getByText("¡Cuenta Creada Exitosamente!", { exact: true })).toBeVisible()
+  await expect(page.getByText("Verifica tu email para continuar", { exact: true })).toBeVisible()
+})

--- a/tests/e2e/auth/route-access.spec.ts
+++ b/tests/e2e/auth/route-access.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test"
+import { resetControlledServices } from "../support/controlled-services-config"
+
+test.beforeEach(async ({ request }) => {
+  await resetControlledServices(request)
+})
+
+test("anonymous visitors are redirected from protected routes to login", async ({ page }) => {
+  await page.goto("/vehicles/vehicle-1?tab=maintenance")
+
+  await expect(page.getByText("Iniciar Sesión", { exact: true }).last()).toBeVisible()
+
+  const currentUrl = new URL(page.url())
+  expect(currentUrl.pathname).toBe("/auth/login")
+  expect(currentUrl.searchParams.get("redirect")).toBe("/vehicles/vehicle-1?tab=maintenance")
+})

--- a/tests/e2e/auth/session-lifecycle.spec.ts
+++ b/tests/e2e/auth/session-lifecycle.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test"
+import { loginWithPassword } from "../support/auth"
+import { resetControlledServices } from "../support/controlled-services-config"
+
+test.beforeEach(async ({ request }) => {
+  await resetControlledServices(request)
+})
+
+test("an authenticated user can log out", async ({ page }) => {
+  await loginWithPassword(page)
+  await expect(page.getByText("Hola, Ada Driver", { exact: true })).toBeVisible()
+
+  await page.getByRole("button", { name: "Abrir menú de usuario" }).click()
+  await page.getByRole("menuitem", { name: "Cerrar Sesión" }).click()
+
+  await expect(page).toHaveURL(/\/auth\/login$/)
+  await expect(page.getByText("Hola, Ada Driver", { exact: true })).toHaveCount(0)
+  await expect(page.getByRole("link", { name: "Iniciar Sesión" })).toBeVisible()
+})
+
+test("authenticated visitors are redirected away from guest-only routes", async ({ page }) => {
+  await loginWithPassword(page)
+
+  await page.goto("/auth/login?redirect=%2Fvehicles")
+
+  await expect(page).toHaveURL(/\/vehicles$/)
+  await expect(page.getByRole("heading", { name: "Mis Vehículos" })).toBeVisible()
+})
+
+test("guest-only redirects reject external destinations", async ({ page }) => {
+  await loginWithPassword(page)
+
+  await page.goto("/auth/login?redirect=https%3A%2F%2Fevil.example%2Fphish")
+
+  await expect(page).toHaveURL("http://localhost:3100/")
+  await expect(page.getByRole("heading", { name: "Panel de Control" })).toBeVisible()
+})
+
+test("an expired session returns the user to login with a safe return path", async ({ page, context }) => {
+  await loginWithPassword(page, "/vehicles")
+  await expect(page.getByText("Hola, Ada Driver", { exact: true })).toBeVisible()
+  await context.clearCookies()
+
+  await page.getByRole("button", { name: "Abrir menú de usuario" }).click()
+  await page.getByRole("menuitem", { name: "Cerrar Sesión" }).click()
+
+  await expect(page).toHaveURL(/\/auth\/login\?redirect=%2Fvehicles$/)
+  await expect(page.getByText("Hola, Ada Driver", { exact: true })).toHaveCount(0)
+})
+
+test("logout in one tab revalidates the authenticated projection in another tab", async ({ page, context }) => {
+  await loginWithPassword(page)
+  const secondPage = await context.newPage()
+  await secondPage.goto("/")
+  await expect(secondPage.getByText("Hola, Ada Driver", { exact: true })).toBeVisible()
+
+  await page.getByRole("button", { name: "Abrir menú de usuario" }).click()
+  await page.getByRole("menuitem", { name: "Cerrar Sesión" }).click()
+
+  await expect(page).toHaveURL(/\/auth\/login$/)
+  await expect(secondPage.getByText("Hola, Ada Driver", { exact: true })).toHaveCount(0)
+  await expect(secondPage.getByRole("banner").getByRole("link", { name: "Iniciar Sesión" })).toBeVisible()
+})

--- a/tests/e2e/support/auth.ts
+++ b/tests/e2e/support/auth.ts
@@ -1,0 +1,10 @@
+import type { Page } from "@playwright/test"
+
+export async function loginWithPassword(page: Page, redirectTo = "/") {
+  const searchParams = new URLSearchParams({ redirect: redirectTo })
+  await page.goto(`/auth/login?${searchParams.toString()}`)
+  await page.getByLabel("Email").fill("driver@keepel.test")
+  await page.getByLabel("Contraseña").fill("correct-horse")
+  await page.getByRole("button", { name: "Iniciar Sesión", exact: true }).click()
+  await page.getByText("Hola, Ada Driver", { exact: true }).waitFor()
+}

--- a/tests/e2e/support/controlled-services-config.ts
+++ b/tests/e2e/support/controlled-services-config.ts
@@ -1,0 +1,10 @@
+import type { APIRequestContext } from "@playwright/test"
+
+export const APP_URL = "http://localhost:3100"
+export const CONTROLLED_SERVICES_URL = "http://127.0.0.1:54321"
+
+export type ControlledOAuthMode = "success" | "cancel" | "provider_error" | "exchange_error"
+
+export async function resetControlledServices(request: APIRequestContext, oauthMode: ControlledOAuthMode = "success") {
+  await request.post(`${CONTROLLED_SERVICES_URL}/__test__/reset`, { data: { oauthMode } })
+}

--- a/tests/e2e/support/controlled-services.ts
+++ b/tests/e2e/support/controlled-services.ts
@@ -1,0 +1,287 @@
+/* eslint-disable no-console -- Controlled E2E service reports startup and request failures. */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
+import { APP_URL, CONTROLLED_SERVICES_URL, type ControlledOAuthMode } from "./controlled-services-config"
+
+const controlledServicesUrl = new URL(CONTROLLED_SERVICES_URL)
+const HOST = controlledServicesUrl.hostname
+const PORT = Number(controlledServicesUrl.port)
+const PASSWORD = "correct-horse"
+
+interface ControlledUser {
+  id: string
+  email: string
+  app_metadata: { provider: "email"; providers: ["email"] }
+  aud: "authenticated"
+  confirmed_at?: string
+  created_at: string
+  email_confirmed_at?: string
+  identities: []
+  is_anonymous: false
+  role: "authenticated"
+  updated_at: string
+  user_metadata: { full_name: string }
+}
+
+const sessions = new Map<string, ControlledUser>()
+let sessionSequence = 0
+let oauthMode: ControlledOAuthMode = "success"
+
+function corsHeaders() {
+  return {
+    "access-control-allow-headers":
+      "accept-profile, apikey, authorization, content-profile, content-type, prefer, x-client-info, x-supabase-api-version",
+    "access-control-allow-methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "access-control-allow-origin": APP_URL,
+    "access-control-expose-headers": "content-range",
+  }
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown, headers: Record<string, string> = {}) {
+  response.writeHead(status, {
+    ...corsHeaders(),
+    "content-type": "application/json",
+    ...headers,
+  })
+  response.end(status === 204 ? undefined : JSON.stringify(body))
+}
+
+function sendRedirect(response: ServerResponse, destination: string) {
+  response.writeHead(302, { ...corsHeaders(), location: destination })
+  response.end()
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+
+  if (chunks.length === 0) {
+    return null
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"))
+}
+
+function encodeJwtPart(value: unknown) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url")
+}
+
+function createAccessToken(user: ControlledUser) {
+  const issuedAt = Math.floor(Date.now() / 1000)
+  const header = encodeJwtPart({ alg: "HS256", typ: "JWT" })
+  const payload = encodeJwtPart({
+    aud: "authenticated",
+    email: user.email,
+    exp: issuedAt + 60 * 60,
+    iat: issuedAt,
+    role: "authenticated",
+    sub: user.id,
+  })
+
+  return `${header}.${payload}.controlled-signature`
+}
+
+function createUser(email: string, fullName = "Ada Driver"): ControlledUser {
+  return {
+    id: "00000000-0000-4000-8000-000000000051",
+    email,
+    app_metadata: { provider: "email", providers: ["email"] },
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00.000Z",
+    identities: [],
+    is_anonymous: false,
+    role: "authenticated",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    user_metadata: { full_name: fullName },
+  }
+}
+
+function createSession(user: ControlledUser) {
+  const accessToken = createAccessToken(user)
+  const refreshToken = `controlled-refresh-${++sessionSequence}`
+  const authenticatedUser = {
+    ...user,
+    confirmed_at: "2026-01-01T00:00:00.000Z",
+    email_confirmed_at: "2026-01-01T00:00:00.000Z",
+  }
+  sessions.set(accessToken, authenticatedUser)
+
+  return {
+    access_token: accessToken,
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: refreshToken,
+    token_type: "bearer",
+    user: authenticatedUser,
+  }
+}
+
+function readBearerToken(request: IncomingMessage) {
+  const authorization = request.headers.authorization
+  return authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : null
+}
+
+function handleRedis(body: unknown) {
+  if (!Array.isArray(body)) {
+    return { result: 1 }
+  }
+
+  const command = String(body[0] ?? "").toLowerCase()
+  return command === "evalsha" || command === "eval" ? { result: [100, 100] } : { result: 1 }
+}
+
+async function handleRequest(request: IncomingMessage, response: ServerResponse) {
+  const url = new URL(request.url ?? "/", `http://${HOST}:${PORT}`)
+
+  if (request.method === "OPTIONS") {
+    sendJson(response, 204, null)
+    return
+  }
+
+  if (request.method === "GET" && url.pathname === "/health") {
+    sendJson(response, 200, { ok: true })
+    return
+  }
+
+  if (request.method === "POST" && url.pathname === "/__test__/reset") {
+    const body = (await readJson(request)) as { oauthMode?: unknown } | null
+    sessions.clear()
+    sessionSequence = 0
+    oauthMode =
+      body?.oauthMode === "cancel" || body?.oauthMode === "provider_error" || body?.oauthMode === "exchange_error"
+        ? body.oauthMode
+        : "success"
+    sendJson(response, 200, { ok: true })
+    return
+  }
+
+  if (request.method === "GET" && url.pathname === "/auth/v1/authorize") {
+    const redirectTo = url.searchParams.get("redirect_to")
+
+    if (!redirectTo) {
+      sendJson(response, 400, { message: "redirect_to is required" })
+      return
+    }
+
+    const callbackUrl = new URL(redirectTo)
+
+    if (oauthMode === "cancel") {
+      callbackUrl.searchParams.set("error", "access_denied")
+      callbackUrl.searchParams.set("error_description", "controlled provider description")
+    } else if (oauthMode === "provider_error") {
+      callbackUrl.searchParams.set("error", "server_error")
+      callbackUrl.searchParams.set("error_description", "controlled-provider-secret")
+    } else {
+      callbackUrl.searchParams.set("code", "controlled-oauth-code")
+    }
+
+    sendRedirect(response, callbackUrl.toString())
+    return
+  }
+
+  if (request.method === "POST" && url.pathname === "/auth/v1/token") {
+    const body = (await readJson(request)) as { email?: unknown; password?: unknown } | null
+    const grantType = url.searchParams.get("grant_type")
+
+    if (grantType === "pkce") {
+      if (oauthMode === "exchange_error") {
+        sendJson(response, 400, {
+          code: "bad_oauth_state",
+          message: "controlled-provider-secret",
+          msg: "controlled-provider-secret",
+        })
+        return
+      }
+
+      sendJson(response, 200, createSession(createUser("driver@keepel.test")))
+      return
+    }
+
+    if (grantType !== "password" || body?.password !== PASSWORD || typeof body.email !== "string") {
+      sendJson(response, 400, {
+        code: "invalid_credentials",
+        error_code: "invalid_credentials",
+        message: "Invalid login credentials",
+        msg: "Invalid login credentials",
+      })
+      return
+    }
+
+    sendJson(response, 200, createSession(createUser(body.email)))
+    return
+  }
+
+  if (request.method === "POST" && url.pathname === "/auth/v1/signup") {
+    const body = (await readJson(request)) as { email?: unknown; data?: { full_name?: unknown } } | null
+
+    if (typeof body?.email !== "string") {
+      sendJson(response, 400, { code: "validation_failed", message: "Email is required" })
+      return
+    }
+
+    const fullName = typeof body.data?.full_name === "string" ? body.data.full_name : "Keepel User"
+    sendJson(response, 200, {
+      ...createUser(body.email, fullName),
+      confirmation_sent_at: "2026-01-01T00:00:00.000Z",
+    })
+    return
+  }
+
+  if (request.method === "GET" && url.pathname === "/auth/v1/user") {
+    const accessToken = readBearerToken(request)
+    const user = accessToken ? sessions.get(accessToken) : null
+
+    if (!user) {
+      sendJson(response, 401, {
+        code: "session_not_found",
+        error_code: "session_not_found",
+        message: "Auth session missing!",
+        msg: "Auth session missing!",
+      })
+      return
+    }
+
+    sendJson(response, 200, user)
+    return
+  }
+
+  if (request.method === "GET" && url.pathname.startsWith("/rest/v1/")) {
+    sendJson(response, 200, [], { "content-range": "0-0/0" })
+    return
+  }
+
+  if (request.method === "POST" && url.pathname === "/pipeline") {
+    const commands = await readJson(request)
+    const results = Array.isArray(commands) ? commands.map(handleRedis) : []
+    sendJson(response, 200, results)
+    return
+  }
+
+  if (request.method === "POST" && url.pathname === "/") {
+    sendJson(response, 200, handleRedis(await readJson(request)))
+    return
+  }
+
+  sendJson(response, 404, { message: "Not found" })
+}
+
+const server = createServer((request, response) => {
+  void handleRequest(request, response).catch((error) => {
+    console.error(error)
+    sendJson(response, 500, { message: "Controlled service failure" })
+  })
+})
+
+server.listen(PORT, HOST, () => {
+  console.log(`Controlled services listening on http://${HOST}:${PORT}`)
+})
+
+function shutdown() {
+  server.close(() => process.exit(0))
+}
+
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)

--- a/tests/integration/auth/cross-tab-invalidation.test.ts
+++ b/tests/integration/auth/cross-tab-invalidation.test.ts
@@ -154,8 +154,8 @@ describe("cross-tab authentication invalidation", () => {
     expect(tabs.hub.messages).toEqual([AUTH_INVALIDATION_EVENT])
     expect(tabs.senderEvents).toEqual([
       "invalidate",
-      "navigate:/auth/login?redirect=%2Fvehicles%2Fvehicle-1",
       "refresh",
+      "navigate:/auth/login?redirect=%2Fvehicles%2Fvehicle-1",
     ])
     expect(tabs.receiverEvents).toEqual(["invalidate", "refresh"])
 

--- a/tests/integration/auth/session-expiry-recovery.test.ts
+++ b/tests/integration/auth/session-expiry-recovery.test.ts
@@ -38,6 +38,6 @@ describe("session expiry recovery", () => {
       error: { code: AUTH_ERROR_CODE.SESSION_EXPIRED },
     })
     expect(recovered).toBe(true)
-    expect(recoveryEvents).toEqual(["invalidate", "navigate:/auth/login?redirect=%2F", "refresh"])
+    expect(recoveryEvents).toEqual(["invalidate", "refresh", "navigate:/auth/login?redirect=%2F"])
   })
 })


### PR DESCRIPTION
## Summary

- add deterministic Playwright coverage for password login, confirmation-required signup, logout, protected and guest-only routes, session expiration, and cross-tab invalidation
- exercise Google OAuth initiation and PKCE callbacks through controlled success, cancellation, and exchange-failure boundaries
- fix expired-session navigation ordering discovered by the browser suite and add an accessible desktop user-menu label
- document automated and manual authentication verification commands

## Verification

- `bun run test` — 114 passed
- `bun run test:e2e` — 12 passed
- `bun lint`
- `bun run fmt:check`
- `bun run type-check`
- `bun run build`

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
