### PR TITLE
Fix privacy consent persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,9 @@ UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 KEEPEL_RATE_LIMIT_HMAC_SECRET=
 
-# Signed privacy preference cookie
+# Required signed privacy preference cookie secret (minimum 32 characters)
+# Generate distinct random values for local, preview, and production environments.
+# Store real values in local/deployment secret management; never commit them.
 KEEPEL_CONSENT_SIGNING_SECRET=
 
 # Server-only OpenPanel writer

--- a/README.md
+++ b/README.md
@@ -271,6 +271,16 @@ OPENPANEL_SERVER_CLIENT_ID=
 OPENPANEL_SERVER_CLIENT_SECRET=
 ```
 
+`KEEPEL_CONSENT_SIGNING_SECRET` es obligatorio y debe tener al menos 32 caracteres. Genera un valor aleatorio independiente para cada entorno (local, preview y producción), por ejemplo:
+
+```bash
+openssl rand -base64 32
+```
+
+Guarda el valor local en `.env.local` y los valores de preview/producción en el gestor de secretos de la plataforma de despliegue. No reutilices valores entre entornos ni guardes secretos generados en el repositorio. `bun run build`, `bun dev` y `bun start` fallan de forma explícita si esta variable falta o es demasiado corta.
+
+Rotar el secreto invalida las preferencias firmadas anteriormente. Tras una rotación, el banner volverá a mostrarse y la analítica permanecerá desactivada hasta que la persona usuaria elija de nuevo.
+
 Las credenciales de OpenPanel son exclusivamente de servidor. Keepel no utiliza una clave `SUPABASE_SERVICE_ROLE_KEY` en la aplicación.
 
 #### 4. Configurar Base de Datos

--- a/app/actions/privacy.ts
+++ b/app/actions/privacy.ts
@@ -1,21 +1,17 @@
 "use server"
 
-import { z } from "zod"
-import { PRIVACY_CONSENT_CHOICES, type PrivacyConsentState } from "@/lib/privacy/consent"
+/* eslint-disable no-console -- Server actions log unexpected consent failures without sensitive context. */
+
+import { createSavePrivacyConsent, type SavePrivacyConsentResult } from "@/lib/privacy/save-consent"
 import { persistPrivacyConsent } from "@/lib/privacy/server"
 
-const privacyChoiceSchema = z.enum(PRIVACY_CONSENT_CHOICES)
-
-export type SavePrivacyConsentResult = { status: "success"; consent: PrivacyConsentState } | { status: "error" }
+const saveConsent = createSavePrivacyConsent({
+  persistConsent: persistPrivacyConsent,
+  reportUnexpectedFailure: () => {
+    console.error("Unexpected privacy consent persistence failure.")
+  },
+})
 
 export async function savePrivacyConsent(choice: unknown): Promise<SavePrivacyConsentResult> {
-  const parsedChoice = privacyChoiceSchema.safeParse(choice)
-
-  if (!parsedChoice.success) {
-    return { status: "error" }
-  }
-
-  const consent = await persistPrivacyConsent(parsedChoice.data)
-
-  return consent ? { status: "success", consent } : { status: "error" }
+  return saveConsent(choice)
 }

--- a/docs/manual-testing/privacy-and-cookies.md
+++ b/docs/manual-testing/privacy-and-cookies.md
@@ -5,6 +5,9 @@ Run this checklist on a preview first and repeat it on `https://keepel.chemicald
 ## Configuration
 
 - Set distinct high-entropy values for `KEEPEL_CONSENT_SIGNING_SECRET` and `KEEPEL_RATE_LIMIT_HMAC_SECRET`.
+- Confirm `KEEPEL_CONSENT_SIGNING_SECRET` contains at least 32 characters and differs across local, preview, and production environments.
+- Confirm a build and server startup with a missing or short consent secret stop with `KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters.`
+- Confirm no real consent secret appears in the repository, logs, or release artifacts.
 - Configure `OPENPANEL_API_URL`, `OPENPANEL_SERVER_CLIENT_ID`, and `OPENPANEL_SERVER_CLIENT_SECRET` for the Spain-hosted writer.
 - Set `APP_BASE_URL=https://keepel.chemicaldev.com` in production.
 - Confirm Supabase and Upstash are in Frankfurt.
@@ -23,10 +26,12 @@ Run this checklist on a preview first and repeat it on `https://keepel.chemicald
 
 1. Use a clean browser profile and open `/privacidad` and `/` without signing in.
 2. Confirm the banner appears, both choices are equally visible, and keyboard focus remains usable.
-3. Reject analytics and reload. Confirm the banner stays hidden and the `keepel_privacy_consent` cookie is `HttpOnly`, `SameSite=Lax`, `Secure`, and expires within 12 months.
-4. Open **Configurar cookies** from the footer, accept analytics, and reload.
-5. Withdraw consent again and confirm later successful operations do not produce events.
-6. Tamper with or delete the preference cookie and confirm analytics fails closed and the banner returns.
+3. Accept analytics directly from the banner and reload. Confirm the banner stays hidden and a supported successful operation produces the expected property-free server event.
+4. In a clean profile, reject analytics directly from the banner and reload. Confirm the banner stays hidden, later successful operations produce no events, and the `keepel_privacy_consent` cookie is `HttpOnly`, `SameSite=Lax`, `Secure`, and expires within 12 months.
+5. Open **Configurar cookies** from the footer, change the preference, and reload.
+6. Withdraw consent again and confirm later successful operations do not produce events.
+7. Tamper with or delete the preference cookie and confirm analytics fails closed and the banner returns.
+8. Rotate the consent secret in a test environment. Confirm the old cookie becomes unverifiable, the banner returns, analytics remains disabled, and a new accept or reject choice persists after reload.
 
 ## Browser analytics boundary
 

--- a/lib/privacy/config.d.mts
+++ b/lib/privacy/config.d.mts
@@ -1,0 +1,5 @@
+export const CONSENT_SIGNING_SECRET_ERROR: string
+
+export function isValidConsentSigningSecret(value: unknown): value is string
+
+export function getRequiredConsentSigningSecret(env?: Record<string, string | undefined>): string

--- a/lib/privacy/config.mjs
+++ b/lib/privacy/config.mjs
@@ -1,0 +1,26 @@
+const MINIMUM_CONSENT_SIGNING_SECRET_LENGTH = 32
+
+export const CONSENT_SIGNING_SECRET_ERROR =
+  "KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters."
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+export function isValidConsentSigningSecret(value) {
+  return typeof value === "string" && value.length >= MINIMUM_CONSENT_SIGNING_SECRET_LENGTH
+}
+
+/**
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {string}
+ */
+export function getRequiredConsentSigningSecret(env = process.env) {
+  const secret = env.KEEPEL_CONSENT_SIGNING_SECRET
+
+  if (!isValidConsentSigningSecret(secret)) {
+    throw new Error(CONSENT_SIGNING_SECRET_ERROR)
+  }
+
+  return secret
+}

--- a/lib/privacy/consent.ts
+++ b/lib/privacy/consent.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer"
 import { createHmac, timingSafeEqual } from "node:crypto"
+import { isValidConsentSigningSecret } from "@/lib/privacy/config.mjs"
 
 export const PRIVACY_POLICY_VERSION = "1.0"
 export const PRIVACY_CONSENT_COOKIE_NAME = "keepel_privacy_consent"
@@ -7,7 +8,6 @@ export const PRIVACY_CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 
 const CONSENT_COOKIE_FORMAT_VERSION = 1
 const MAX_FUTURE_CLOCK_SKEW_MS = 5 * 60 * 1000
-const MINIMUM_SECRET_LENGTH = 32
 
 export const PRIVACY_CONSENT_CHOICES = ["accepted", "rejected"] as const
 
@@ -31,10 +31,6 @@ export const UNKNOWN_PRIVACY_CONSENT: PrivacyConsentState = {
   preference: "unknown",
   decidedAt: null,
   policyVersion: null,
-}
-
-function hasValidSecret(secret: string | undefined): secret is string {
-  return typeof secret === "string" && secret.length >= MINIMUM_SECRET_LENGTH
 }
 
 function isConsentChoice(value: unknown): value is PrivacyConsentChoice {
@@ -86,7 +82,7 @@ export function createPrivacyConsentCookieValue(
   secret: string | undefined,
   now = new Date()
 ): string | null {
-  if (!hasValidSecret(secret)) {
+  if (!isValidConsentSigningSecret(secret)) {
     return null
   }
 
@@ -105,7 +101,7 @@ export function parsePrivacyConsentCookieValue(
   secret: string | undefined,
   now = new Date()
 ): PrivacyConsentState {
-  if (!value || !hasValidSecret(secret)) {
+  if (!value || !isValidConsentSigningSecret(secret)) {
     return UNKNOWN_PRIVACY_CONSENT
   }
 

--- a/lib/privacy/save-consent.ts
+++ b/lib/privacy/save-consent.ts
@@ -1,0 +1,34 @@
+import { z } from "zod"
+import { PRIVACY_CONSENT_CHOICES, type PrivacyConsentChoice, type PrivacyConsentState } from "@/lib/privacy/consent"
+
+const privacyChoiceSchema = z.enum(PRIVACY_CONSENT_CHOICES)
+
+export type SavePrivacyConsentResult = { status: "success"; consent: PrivacyConsentState } | { status: "error" }
+
+interface SavePrivacyConsentDependencies {
+  persistConsent(choice: PrivacyConsentChoice): Promise<PrivacyConsentState>
+  reportUnexpectedFailure(): void
+}
+
+export function createSavePrivacyConsent({
+  persistConsent,
+  reportUnexpectedFailure,
+}: SavePrivacyConsentDependencies): (choice: unknown) => Promise<SavePrivacyConsentResult> {
+  return async (choice) => {
+    const parsedChoice = privacyChoiceSchema.safeParse(choice)
+
+    if (!parsedChoice.success) {
+      return { status: "error" }
+    }
+
+    try {
+      const consent = await persistConsent(parsedChoice.data)
+
+      return { status: "success", consent }
+    } catch {
+      reportUnexpectedFailure()
+
+      return { status: "error" }
+    }
+  }
+}

--- a/lib/privacy/server.ts
+++ b/lib/privacy/server.ts
@@ -8,38 +8,79 @@ import {
   parsePrivacyConsentCookieValue,
   type PrivacyConsentChoice,
   type PrivacyConsentState,
-} from "./consent"
+} from "@/lib/privacy/consent"
+import { getRequiredConsentSigningSecret } from "@/lib/privacy/config.mjs"
 
-function getConsentSecret() {
-  return process.env.KEEPEL_CONSENT_SIGNING_SECRET
+interface PrivacyConsentCookieOptions {
+  httpOnly: boolean
+  maxAge: number
+  path: string
+  sameSite: "lax"
+  secure: boolean
 }
 
-export function getPrivacyConsentCookieOptions() {
+interface PrivacyConsentCookieStore {
+  get(name: string): { value: string } | undefined
+  set(name: string, value: string, options: PrivacyConsentCookieOptions): void
+}
+
+interface PrivacyConsentPersistenceDependencies {
+  getCookieStore(): Promise<PrivacyConsentCookieStore>
+  getSigningSecret(): string
+  now?: () => Date
+  nodeEnvironment?: typeof process.env.NODE_ENV
+}
+
+export function getPrivacyConsentCookieOptions(nodeEnvironment = process.env.NODE_ENV): PrivacyConsentCookieOptions {
   return {
     httpOnly: true,
     maxAge: PRIVACY_CONSENT_MAX_AGE_SECONDS,
     path: "/",
-    sameSite: "lax" as const,
-    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    secure: nodeEnvironment === "production",
   }
 }
+
+export function createPrivacyConsentPersistence({
+  getCookieStore,
+  getSigningSecret,
+  now = () => new Date(),
+  nodeEnvironment = process.env.NODE_ENV,
+}: PrivacyConsentPersistenceDependencies) {
+  return {
+    async read(): Promise<PrivacyConsentState> {
+      const cookieStore = await getCookieStore()
+      const secret = getSigningSecret()
+
+      return parsePrivacyConsentCookieValue(cookieStore.get(PRIVACY_CONSENT_COOKIE_NAME)?.value, secret, now())
+    },
+
+    async persist(choice: PrivacyConsentChoice): Promise<PrivacyConsentState> {
+      const cookieStore = await getCookieStore()
+      const secret = getSigningSecret()
+      const decisionTime = now()
+      const value = createPrivacyConsentCookieValue(choice, secret, decisionTime)
+
+      if (!value) {
+        throw new Error("Privacy consent cookie signing failed.")
+      }
+
+      cookieStore.set(PRIVACY_CONSENT_COOKIE_NAME, value, getPrivacyConsentCookieOptions(nodeEnvironment))
+
+      return parsePrivacyConsentCookieValue(value, secret, decisionTime)
+    },
+  }
+}
+
+const privacyConsentPersistence = createPrivacyConsentPersistence({
+  getCookieStore: cookies,
+  getSigningSecret: getRequiredConsentSigningSecret,
+})
 
 export async function readPrivacyConsent(): Promise<PrivacyConsentState> {
-  const cookieStore = await cookies()
-
-  return parsePrivacyConsentCookieValue(cookieStore.get(PRIVACY_CONSENT_COOKIE_NAME)?.value, getConsentSecret())
+  return privacyConsentPersistence.read()
 }
 
-export async function persistPrivacyConsent(choice: PrivacyConsentChoice): Promise<PrivacyConsentState | null> {
-  const cookieStore = await cookies()
-  const now = new Date()
-  const value = createPrivacyConsentCookieValue(choice, getConsentSecret(), now)
-
-  if (!value) {
-    return null
-  }
-
-  cookieStore.set(PRIVACY_CONSENT_COOKIE_NAME, value, getPrivacyConsentCookieOptions())
-
-  return parsePrivacyConsentCookieValue(value, getConsentSecret(), now)
+export async function persistPrivacyConsent(choice: PrivacyConsentChoice): Promise<PrivacyConsentState> {
+  return privacyConsentPersistence.persist(choice)
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,7 @@
+import { getRequiredConsentSigningSecret } from "./lib/privacy/config.mjs"
+
+getRequiredConsentSigningSecret()
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {

--- a/tests/e2e/privacy/privacy-and-cookies.spec.ts
+++ b/tests/e2e/privacy/privacy-and-cookies.spec.ts
@@ -1,5 +1,55 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type APIRequestContext, type BrowserContext, type Page } from "@playwright/test"
 import { CONTROLLED_SERVICES_URL } from "../support/controlled-services-config"
+
+const ONE_DAY_SECONDS = 60 * 60 * 24
+
+function collectBrowserAnalyticsRequests(page: Page) {
+  const requests: string[] = []
+
+  page.on("request", (request) => {
+    if (request.url().includes("openpanel")) {
+      requests.push(request.url())
+    }
+  })
+
+  return requests
+}
+
+async function expectPersistedConsentCookie(context: BrowserContext) {
+  const cookie = (await context.cookies()).find((candidate) => candidate.name === "keepel_privacy_consent")
+
+  expect(cookie).toMatchObject({ httpOnly: true, path: "/", sameSite: "Lax", secure: false })
+  expect(cookie?.expires).toBeGreaterThan(Date.now() / 1000 + 364 * ONE_DAY_SECONDS)
+  expect(cookie?.expires).toBeLessThanOrEqual(Date.now() / 1000 + 366 * ONE_DAY_SECONDS)
+}
+
+async function loginWithEmail(page: Page) {
+  await page.goto("/auth/login")
+  await page.getByLabel("Email").fill("driver@keepel.test")
+  await page.getByLabel("Contraseña").fill("correct-horse")
+  await page.getByRole("button", { name: "Iniciar Sesión", exact: true }).click()
+  await expect(page).toHaveURL(/\/$/)
+}
+
+async function readAnalyticsEvents(request: APIRequestContext) {
+  const response = await request.get(`${CONTROLLED_SERVICES_URL}/__test__/analytics`)
+  const body = (await response.json()) as { events: unknown[] }
+
+  return body.events
+}
+
+const consentJourneys = [
+  {
+    choice: "accepts" as const,
+    buttonName: "Aceptar analítica",
+    expectedEvents: [{ type: "track", payload: { name: "auth_login_email_succeeded" } }],
+  },
+  {
+    choice: "rejects" as const,
+    buttonName: "Rechazar analítica",
+    expectedEvents: [],
+  },
+]
 
 test.describe("privacy and cookies", () => {
   test("publishes the combined policy and global privacy controls", async ({ page }) => {
@@ -13,54 +63,53 @@ test.describe("privacy and cookies", () => {
     await expect(page.getByRole("button", { name: "Configurar cookies" })).toBeVisible()
   })
 
-  test("rejects optional analytics, persists the choice, and allows changing it", async ({
-    context,
-    page,
-    request,
-  }) => {
-    await request.post(`${CONTROLLED_SERVICES_URL}/__test__/reset`, { data: {} })
+  for (const journey of consentJourneys) {
+    test(`${journey.choice} optional analytics and persists the choice after reload`, async ({
+      context,
+      page,
+      request,
+    }) => {
+      await request.post(`${CONTROLLED_SERVICES_URL}/__test__/reset`, { data: {} })
+      const browserAnalyticsRequests = collectBrowserAnalyticsRequests(page)
 
-    const browserAnalyticsRequests: string[] = []
-    page.on("request", (browserRequest) => {
-      if (browserRequest.url().includes("openpanel")) {
-        browserAnalyticsRequests.push(browserRequest.url())
+      await page.goto("/")
+
+      const accept = page.getByRole("button", { name: "Aceptar analítica" })
+      const reject = page.getByRole("button", { name: "Rechazar analítica" })
+      await expect(accept).toBeVisible()
+      await expect(reject).toBeVisible()
+
+      await page.getByRole("button", { name: journey.buttonName }).click()
+      await expect(accept).toBeHidden()
+      await expect(reject).toBeHidden()
+      await expectPersistedConsentCookie(context)
+
+      await page.reload()
+      await expect(accept).toBeHidden()
+      await expect(reject).toBeHidden()
+
+      await loginWithEmail(page)
+
+      if (journey.expectedEvents.length > 0) {
+        await expect.poll(() => readAnalyticsEvents(request)).toEqual(journey.expectedEvents)
+      } else {
+        await page.waitForTimeout(500)
+        expect(await readAnalyticsEvents(request)).toEqual([])
       }
+
+      expect(browserAnalyticsRequests).toEqual([])
     })
+  }
 
+  test("allows changing privacy preferences from the global control", async ({ page }) => {
     await page.goto("/")
-
-    const accept = page.getByRole("button", { name: "Aceptar analítica" })
-    const reject = page.getByRole("button", { name: "Rechazar analítica" })
-    await expect(accept).toBeVisible()
-    await expect(reject).toBeVisible()
-
-    await reject.click()
-    await expect(reject).toBeHidden()
-    expect(await (await request.get(`${CONTROLLED_SERVICES_URL}/__test__/analytics`)).json()).toEqual({ events: [] })
-
-    const consentCookie = (await context.cookies()).find((cookie) => cookie.name === "keepel_privacy_consent")
-    expect(consentCookie).toMatchObject({ httpOnly: true, sameSite: "Lax" })
-
-    await page.reload()
-    await expect(page.getByRole("button", { name: "Rechazar analítica" })).toBeHidden()
+    await page.getByRole("button", { name: "Rechazar analítica" }).click()
 
     await page.getByRole("button", { name: "Configurar cookies" }).click()
     await expect(page.getByRole("heading", { name: "Preferencias de privacidad" })).toBeVisible()
     expect(await page.evaluate(() => document.activeElement?.closest('[role="dialog"]') !== null)).toBe(true)
     await page.getByRole("button", { name: "Permitir analítica" }).click()
     await expect(page.getByRole("heading", { name: "Preferencias de privacidad" })).toBeHidden()
-
-    await page.goto("/auth/login")
-    await page.getByLabel("Email").fill("driver@keepel.test")
-    await page.getByLabel("Contraseña").fill("correct-horse")
-    await page.getByRole("button", { name: "Iniciar Sesión", exact: true }).click()
-    await expect(page).toHaveURL(/\/$/)
-
-    await expect
-      .poll(async () => (await (await request.get(`${CONTROLLED_SERVICES_URL}/__test__/analytics`)).json()).events)
-      .toEqual([{ type: "track", payload: { name: "auth_login_email_succeeded" } }])
-
-    expect(browserAnalyticsRequests).toEqual([])
   })
 
   test("shows an informational privacy notice at signup without a checkbox", async ({ page }) => {

--- a/tests/integration/privacy/consent-persistence-flow.test.ts
+++ b/tests/integration/privacy/consent-persistence-flow.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import {
+  PRIVACY_CONSENT_COOKIE_NAME,
+  PRIVACY_CONSENT_MAX_AGE_SECONDS,
+  UNKNOWN_PRIVACY_CONSENT,
+  allowsAnonymousAnalytics,
+} from "@/lib/privacy/consent"
+import { createPrivacyConsentPersistence } from "@/lib/privacy/server"
+
+const signingSecret = "consent-secret-that-is-at-least-32-characters-long"
+const now = new Date("2026-07-25T12:00:00.000Z")
+
+interface RecordedCookie {
+  value: string
+  options: {
+    httpOnly: boolean
+    maxAge: number
+    path: string
+    sameSite: "lax"
+    secure: boolean
+  }
+}
+
+function createCookieStore(cookies = new Map<string, RecordedCookie>()) {
+  return {
+    cookies,
+    store: {
+      get(name: string) {
+        const cookie = cookies.get(name)
+        return cookie ? { value: cookie.value } : undefined
+      },
+      set(name: string, value: string, options: RecordedCookie["options"]) {
+        cookies.set(name, { value, options })
+      },
+    },
+  }
+}
+
+describe("privacy consent persistence", () => {
+  it.each([
+    { choice: "accepted" as const, allowsAnalytics: true },
+    { choice: "rejected" as const, allowsAnalytics: false },
+  ])("persists $choice consent across requests", async ({ choice, allowsAnalytics }) => {
+    const { cookies, store } = createCookieStore()
+    const persistence = createPrivacyConsentPersistence({
+      getCookieStore: async () => store,
+      getSigningSecret: () => signingSecret,
+      now: () => now,
+      nodeEnvironment: "production",
+    })
+
+    expect(await persistence.read()).toEqual(UNKNOWN_PRIVACY_CONSENT)
+
+    const saved = await persistence.persist(choice)
+    const cookie = cookies.get(PRIVACY_CONSENT_COOKIE_NAME)
+
+    expect(saved).toEqual({
+      preference: choice,
+      decidedAt: now.toISOString(),
+      policyVersion: "1.0",
+    })
+    expect(cookie?.options).toEqual({
+      httpOnly: true,
+      maxAge: PRIVACY_CONSENT_MAX_AGE_SECONDS,
+      path: "/",
+      sameSite: "lax",
+      secure: true,
+    })
+
+    const nextRequest = createPrivacyConsentPersistence({
+      getCookieStore: async () => store,
+      getSigningSecret: () => signingSecret,
+      now: () => now,
+      nodeEnvironment: "production",
+    })
+    const restored = await nextRequest.read()
+
+    expect(restored).toEqual(saved)
+    expect(allowsAnonymousAnalytics(restored)).toBe(allowsAnalytics)
+  })
+
+  it("fails closed after rotating the signing secret", async () => {
+    const { store } = createCookieStore()
+    const oldPersistence = createPrivacyConsentPersistence({
+      getCookieStore: async () => store,
+      getSigningSecret: () => signingSecret,
+      now: () => now,
+    })
+    await oldPersistence.persist("accepted")
+
+    const rotatedPersistence = createPrivacyConsentPersistence({
+      getCookieStore: async () => store,
+      getSigningSecret: () => "rotated-consent-secret-that-is-at-least-32-characters",
+      now: () => now,
+    })
+    const restored = await rotatedPersistence.read()
+
+    expect(restored).toEqual(UNKNOWN_PRIVACY_CONSENT)
+    expect(allowsAnonymousAnalytics(restored)).toBe(false)
+  })
+})

--- a/tests/integration/privacy/next-config-validation.test.ts
+++ b/tests/integration/privacy/next-config-validation.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const projectRoot = fileURLToPath(new URL("../../..", import.meta.url))
+const expectedError = "KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters."
+
+function importNextConfig(secret?: string) {
+  const environment = { ...process.env }
+
+  if (secret === undefined) {
+    delete environment.KEEPEL_CONSENT_SIGNING_SECRET
+  } else {
+    environment.KEEPEL_CONSENT_SIGNING_SECRET = secret
+  }
+
+  return spawnSync("node", ["--input-type=module", "--eval", 'await import("./next.config.mjs")'], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    env: environment,
+  })
+}
+
+describe("Next privacy configuration", () => {
+  it.each([undefined, "too-short"])("fails while loading when the consent secret is invalid", (secret) => {
+    const result = importNextConfig(secret)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}${result.stderr}`).toContain(expectedError)
+  })
+
+  it("loads with a valid consent secret", () => {
+    const result = importNextConfig("consent-secret-that-is-long-enough")
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe("")
+  })
+})

--- a/tests/unit/privacy/config.test.ts
+++ b/tests/unit/privacy/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { getRequiredConsentSigningSecret } from "@/lib/privacy/config.mjs"
+
+const expectedError = "KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters."
+
+describe("privacy consent configuration", () => {
+  it.each([undefined, "short-secret-that-is-not-enough"])("rejects a missing or short signing secret", (secret) => {
+    expect(() => getRequiredConsentSigningSecret({ KEEPEL_CONSENT_SIGNING_SECRET: secret })).toThrow(expectedError)
+  })
+
+  it("accepts exactly 32 characters and returns the original value", () => {
+    const secret = "x".repeat(32)
+
+    expect(getRequiredConsentSigningSecret({ KEEPEL_CONSENT_SIGNING_SECRET: secret })).toBe(secret)
+  })
+
+  it("validates only the consent signing secret", () => {
+    const secret = "consent-secret-that-is-long-enough"
+
+    expect(getRequiredConsentSigningSecret({ KEEPEL_CONSENT_SIGNING_SECRET: secret, OTHER_SECRET: undefined })).toBe(
+      secret
+    )
+  })
+
+  it("never includes an invalid secret in the configuration error", () => {
+    const secret = "sensitive-short-secret"
+
+    expect(() => getRequiredConsentSigningSecret({ KEEPEL_CONSENT_SIGNING_SECRET: secret })).toThrow(expectedError)
+
+    try {
+      getRequiredConsentSigningSecret({ KEEPEL_CONSENT_SIGNING_SECRET: secret })
+    } catch (error) {
+      expect(String(error)).not.toContain(secret)
+    }
+  })
+})

--- a/tests/unit/privacy/consent.test.ts
+++ b/tests/unit/privacy/consent.test.ts
@@ -46,6 +46,15 @@ describe("privacy consent cookie", () => {
     expect(parsePrivacyConsentCookieValue(value ?? undefined, secret, afterExpiry)).toEqual(UNKNOWN_PRIVACY_CONSENT)
   })
 
+  it.each(["accepted", "rejected"] as const)("fails closed after rotating a %s preference", (choice) => {
+    const value = createPrivacyConsentCookieValue(choice, secret, now)
+    const rotatedSecret = "rotated-consent-secret-that-is-at-least-32-characters"
+    const parsed = parsePrivacyConsentCookieValue(value ?? undefined, rotatedSecret, now)
+
+    expect(parsed).toEqual(UNKNOWN_PRIVACY_CONSENT)
+    expect(allowsAnonymousAnalytics(parsed)).toBe(false)
+  })
+
   it("refuses short signing secrets", () => {
     expect(createPrivacyConsentCookieValue("accepted", "too-short", now)).toBeNull()
     expect(parsePrivacyConsentCookieValue("value.signature", "too-short", now)).toEqual(UNKNOWN_PRIVACY_CONSENT)

--- a/tests/unit/privacy/save-consent.test.ts
+++ b/tests/unit/privacy/save-consent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest"
+import { createSavePrivacyConsent } from "@/lib/privacy/save-consent"
+import type { PrivacyConsentChoice, PrivacyConsentState } from "@/lib/privacy/consent"
+
+function consentState(preference: PrivacyConsentChoice): PrivacyConsentState {
+  return {
+    preference,
+    decidedAt: "2026-07-25T12:00:00.000Z",
+    policyVersion: "1.0",
+  }
+}
+
+describe("save privacy consent", () => {
+  it("rejects invalid input without persisting or reporting an operational failure", async () => {
+    const persistConsent = vi.fn()
+    const reportUnexpectedFailure = vi.fn()
+    const saveConsent = createSavePrivacyConsent({ persistConsent, reportUnexpectedFailure })
+
+    await expect(saveConsent("invalid-choice")).resolves.toEqual({ status: "error" })
+    expect(persistConsent).not.toHaveBeenCalled()
+    expect(reportUnexpectedFailure).not.toHaveBeenCalled()
+  })
+
+  it.each(["accepted", "rejected"] as const)("returns persisted %s consent", async (choice) => {
+    const consent = consentState(choice)
+    const persistConsent = vi.fn().mockResolvedValue(consent)
+    const saveConsent = createSavePrivacyConsent({ persistConsent, reportUnexpectedFailure: vi.fn() })
+
+    await expect(saveConsent(choice)).resolves.toEqual({ status: "success", consent })
+    expect(persistConsent).toHaveBeenCalledOnce()
+    expect(persistConsent).toHaveBeenCalledWith(choice)
+  })
+
+  it("returns a sanitized error and reports unexpected failures without arguments", async () => {
+    const sensitiveFailure = new Error("secret=cookie=user=request")
+    const reportUnexpectedFailure = vi.fn()
+    const saveConsent = createSavePrivacyConsent({
+      persistConsent: vi.fn().mockRejectedValue(sensitiveFailure),
+      reportUnexpectedFailure,
+    })
+
+    await expect(saveConsent("accepted")).resolves.toEqual({ status: "error" })
+    expect(reportUnexpectedFailure).toHaveBeenCalledOnce()
+    expect(reportUnexpectedFailure).toHaveBeenCalledWith()
+    expect(reportUnexpectedFailure.mock.calls.flat()).not.toContain(sensitiveFailure)
+  })
+})


### PR DESCRIPTION
## Summary

- fail fast during Next.js build and startup when `KEEPEL_CONSENT_SIGNING_SECRET` is missing or shorter than 32 characters
- persist accepted and rejected consent through a testable signed-cookie boundary while preserving fail-closed behavior for invalid or rotated cookies
- keep browser errors sanitized and emit only a fixed, secret-safe server diagnostic for unexpected persistence failures
- add unit, integration, and Playwright coverage for configuration, both consent choices, reload persistence, cookie security properties, analytics gating, and secret rotation
- document per-environment secret generation, deployment storage, and rotation behavior

## Security and architecture

- validates only the server-side consent signing secret and never exposes its value to the browser or logs
- preserves the ADR requirement that malformed, expired, or unverifiable consent disables analytics
- keeps local, preview, and production secrets distinct; no real secret is committed
- rotating the secret intentionally returns existing consent to the unknown state until the user chooses again

## Verification

- `bun lint`
- `bun type-check`
- `bun run test` — 153 passed
- `bun run test:e2e` — 17 passed
- `bun run build`
- focused `bun fmt:check` for all changed files
- verified `bun run build` and `bun start` reject a short secret with the approved configuration error

Repository-wide `bun fmt:check` remains blocked by a pre-existing formatting issue in `.engram/config.json`; all files changed by this PR pass formatting. The full E2E suite also emits pre-existing vehicle-dialog hydration warnings while all tests pass.

## Deployment

Distinct secrets are already configured in the Dokploy preview and production environment settings. Production still requires a redeploy to load the new value into the running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)