### PR TITLE
fix(auth): handle dependency outages safely

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,3 +7,11 @@ Keepel es un servicio para que personas particulares organicen la información d
 **Persona usuaria**:
 Persona física mayor de 18 años que crea una cuenta de Keepel para gestionar información de sus vehículos.
 _Avoid_: Cliente, conductor, titular de la cuenta
+
+**Intento de inicio de sesión**:
+Solicitud para acceder a Keepel mediante unas credenciales. Puede terminar con acceso concedido, credenciales no válidas o inicio de sesión temporalmente no disponible. El resultado no revela si existe una cuenta asociada al email.
+_Avoid_: Comprobación de cuenta, búsqueda de usuario
+
+**Referencia de incidente**:
+Identificador opaco que una persona usuaria puede comunicar a soporte para relacionar un resultado temporalmente no disponible con su diagnóstico interno. No contiene datos personales ni credenciales.
+_Avoid_: Código de error, identificador de usuario

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,18 +1,18 @@
 "use server"
 
-/* eslint-disable no-console -- Server actions log unexpected auth failures until centralized observability is added. */
-
 import { revalidatePath } from "next/cache"
 import { headers } from "next/headers"
 import { recordAnonymousAnalytics } from "@/lib/analytics/anonymous-analytics"
 import {
   AUTH_COMMAND_STATUS,
-  AUTH_ERROR_CODE,
+  AUTH_UNAVAILABLE_STAGE,
   SIGN_UP_RATE_LIMIT_SCOPE,
   SIGN_UP_STATUS,
   type SignUpResult,
 } from "@/lib/auth/contracts"
 import { createPasswordLoginCommand, type PasswordLoginResult } from "@/lib/auth/password-login"
+import { reportAuthUnavailable } from "@/lib/auth/auth-unavailable"
+import { createTemporarilyUnavailableError } from "@/lib/auth/temporarily-unavailable"
 import { createLogoutCommand, type LogoutResult } from "@/lib/auth/logout"
 import { getCurrentUser, requireCurrentUser } from "@/lib/auth/server"
 import { createSignupCommand } from "@/lib/auth/signup"
@@ -36,6 +36,7 @@ const passwordLogin = createPasswordLoginCommand({
       return emailLimit.success && ipLimit.success
     },
   },
+  reportUnavailable: reportAuthUnavailable,
 })
 
 const logout = createLogoutCommand({
@@ -72,6 +73,7 @@ const signup = createSignupCommand({
           }
     },
   },
+  reportUnavailable: reportAuthUnavailable,
 })
 
 export async function loginAction(
@@ -93,12 +95,10 @@ export async function loginAction(
     }
 
     return result
-  } catch (error) {
-    console.error("Unexpected password login action failure:", error)
-
+  } catch {
     return {
       status: AUTH_COMMAND_STATUS.ERROR,
-      error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+      error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.ACTION, reportAuthUnavailable),
     }
   }
 }
@@ -135,12 +135,10 @@ export async function signupAction(_previousResult: SignUpResult | null, formDat
         process.env.NEXT_PUBLIC_SUPABASE_REDIRECT_URL ||
         "http://localhost:3000/",
     })
-  } catch (error) {
-    console.error("Unexpected signup action failure:", error)
-
+  } catch {
     return {
       status: SIGN_UP_STATUS.ERROR,
-      error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+      error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.ACTION, reportAuthUnavailable),
     }
   }
 }

--- a/components/auth/password-login-feedback.tsx
+++ b/components/auth/password-login-feedback.tsx
@@ -10,6 +10,7 @@ function getPasswordLoginErrorMessage(error: AuthError) {
       return "Revisa el email y la contraseña e inténtalo de nuevo."
     case AUTH_ERROR_CODE.PROVIDER_ERROR:
       return "No pudimos iniciar sesión. Inténtalo de nuevo."
+    case AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE:
     case AUTH_ERROR_CODE.UNEXPECTED:
       return "Ocurrió un error inesperado. Inténtalo de nuevo."
     case AUTH_ERROR_CODE.AUTHENTICATION_REQUIRED:
@@ -34,6 +35,9 @@ export function PasswordLoginFeedback({ error }: PasswordLoginFeedbackProps) {
       className="text-destructive bg-destructive/10 border-destructive/20 rounded-md border p-3 text-sm"
     >
       {getPasswordLoginErrorMessage(error)}
+      {error.code === AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE && (
+        <span className="mt-1 block font-mono text-xs">Referencia: {error.reference}</span>
+      )}
     </div>
   )
 }

--- a/components/auth/signup-feedback.tsx
+++ b/components/auth/signup-feedback.tsx
@@ -16,6 +16,7 @@ function getSignupErrorMessage(error: SignUpError) {
     case AUTH_ERROR_CODE.INVALID_CREDENTIALS:
     case AUTH_ERROR_CODE.PROVIDER_ERROR:
       return "No pudimos crear la cuenta. Inténtalo de nuevo."
+    case AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE:
     case AUTH_ERROR_CODE.UNEXPECTED:
       return "Ocurrió un error inesperado. Inténtalo de nuevo."
     case AUTH_ERROR_CODE.AUTHENTICATION_REQUIRED:
@@ -40,6 +41,9 @@ export function SignupFeedback({ error }: SignupFeedbackProps) {
       className="text-destructive bg-destructive/10 border-destructive/20 rounded-md border p-3 text-sm"
     >
       {getSignupErrorMessage(error)}
+      {error.code === AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE && (
+        <span className="mt-1 block font-mono text-xs">Referencia: {error.reference}</span>
+      )}
     </div>
   )
 }

--- a/lib/auth/auth-unavailable.ts
+++ b/lib/auth/auth-unavailable.ts
@@ -3,7 +3,7 @@ import "server-only"
 /* eslint-disable no-console -- Safe server diagnostics are required until centralized observability is available. */
 
 import { randomUUID } from "node:crypto"
-import type { AuthUnavailableStage } from "./contracts"
+import type { AuthUnavailableStage } from "@/lib/auth/contracts"
 
 export function reportAuthUnavailable(stage: AuthUnavailableStage): string {
   const reference = randomUUID()

--- a/lib/auth/auth-unavailable.ts
+++ b/lib/auth/auth-unavailable.ts
@@ -1,0 +1,14 @@
+import "server-only"
+
+/* eslint-disable no-console -- Safe server diagnostics are required until centralized observability is available. */
+
+import { randomUUID } from "node:crypto"
+import type { AuthUnavailableStage } from "./contracts"
+
+export function reportAuthUnavailable(stage: AuthUnavailableStage): string {
+  const reference = randomUUID()
+
+  console.error("Authentication temporarily unavailable.", { reference, stage })
+
+  return reference
+}

--- a/lib/auth/contracts.ts
+++ b/lib/auth/contracts.ts
@@ -15,6 +15,7 @@ export const AUTH_ERROR_CODE = {
   VALIDATION_FAILED: "validation_failed",
   PROVIDER_ERROR: "provider_error",
   SESSION_EXPIRED: "session_expired",
+  TEMPORARILY_UNAVAILABLE: "temporarily_unavailable",
   UNEXPECTED: "unexpected",
 } as const
 
@@ -35,6 +36,12 @@ export const SIGN_UP_RATE_LIMIT_SCOPE = {
   EMAIL: "email",
 } as const
 
+export const AUTH_UNAVAILABLE_STAGE = {
+  ACTION: "action",
+  AUTH_PROVIDER: "auth_provider",
+  RATE_LIMIT: "rate_limit",
+} as const
+
 type ValueOf<T> = T[keyof T]
 
 declare const userIdBrand: unique symbol
@@ -42,13 +49,16 @@ declare const userIdBrand: unique symbol
 export type UserId = string & { readonly [userIdBrand]: "UserId" }
 
 export type AuthErrorCode = ValueOf<typeof AUTH_ERROR_CODE>
+export type AuthUnavailableStage = ValueOf<typeof AUTH_UNAVAILABLE_STAGE>
 
 export type OAuthErrorCode = ValueOf<typeof OAUTH_ERROR_CODE>
 
 export type SignUpRateLimitScope = ValueOf<typeof SIGN_UP_RATE_LIMIT_SCOPE>
 
 export type AuthError = {
-  [Code in AuthErrorCode]: { code: Code }
+  [Code in AuthErrorCode]: Code extends typeof AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE
+    ? { code: Code; reference: string }
+    : { code: Code }
 }[AuthErrorCode]
 
 export interface CurrentUser {

--- a/lib/auth/password-login.ts
+++ b/lib/auth/password-login.ts
@@ -1,6 +1,7 @@
-import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, type AuthCommandResult } from "./contracts"
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, AUTH_UNAVAILABLE_STAGE, type AuthCommandResult } from "./contracts"
 import { sanitizeInternalRedirect } from "./redirects"
 import { parsePasswordLoginCredentials } from "./password-login-validation"
+import { createTemporarilyUnavailableError, type AuthUnavailableReporter } from "./temporarily-unavailable"
 
 export interface PasswordLoginInput {
   email: unknown
@@ -30,9 +31,14 @@ export interface PasswordLoginRateLimitAdapter {
 interface PasswordLoginDependencies {
   authAdapter: PasswordLoginAuthAdapter
   rateLimitAdapter: PasswordLoginRateLimitAdapter
+  reportUnavailable: AuthUnavailableReporter
 }
 
-export function createPasswordLoginCommand({ authAdapter, rateLimitAdapter }: PasswordLoginDependencies) {
+export function createPasswordLoginCommand({
+  authAdapter,
+  rateLimitAdapter,
+  reportUnavailable,
+}: PasswordLoginDependencies) {
   return async function login(input: PasswordLoginInput): Promise<PasswordLoginResult> {
     const credentials = parsePasswordLoginCredentials({
       email: input.email,
@@ -48,32 +54,52 @@ export function createPasswordLoginCommand({ authAdapter, rateLimitAdapter }: Pa
 
     const { email, password } = credentials.data
 
+    let isAllowed: boolean
+
     try {
-      if (!(await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp }))) {
-        return {
-          status: AUTH_COMMAND_STATUS.ERROR,
-          error: { code: AUTH_ERROR_CODE.RATE_LIMITED },
-        }
-      }
-
-      const result = await authAdapter.signInWithPassword({ email, password })
-
-      if (!result.authenticated) {
-        return {
-          status: AUTH_COMMAND_STATUS.ERROR,
-          error: { code: result.errorCode },
-        }
-      }
-
-      return {
-        status: AUTH_COMMAND_STATUS.SUCCESS,
-        data: { redirectTo: sanitizeInternalRedirect(input.redirectTo) },
-      }
+      isAllowed = await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp })
     } catch {
       return {
         status: AUTH_COMMAND_STATUS.ERROR,
-        error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+        error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.RATE_LIMIT, reportUnavailable),
       }
+    }
+
+    if (!isAllowed) {
+      return {
+        status: AUTH_COMMAND_STATUS.ERROR,
+        error: { code: AUTH_ERROR_CODE.RATE_LIMITED },
+      }
+    }
+
+    let result: PasswordLoginAdapterResult
+
+    try {
+      result = await authAdapter.signInWithPassword({ email, password })
+    } catch {
+      return {
+        status: AUTH_COMMAND_STATUS.ERROR,
+        error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.AUTH_PROVIDER, reportUnavailable),
+      }
+    }
+
+    if (!result.authenticated) {
+      if (result.errorCode === AUTH_ERROR_CODE.PROVIDER_ERROR) {
+        return {
+          status: AUTH_COMMAND_STATUS.ERROR,
+          error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.AUTH_PROVIDER, reportUnavailable),
+        }
+      }
+
+      return {
+        status: AUTH_COMMAND_STATUS.ERROR,
+        error: { code: result.errorCode },
+      }
+    }
+
+    return {
+      status: AUTH_COMMAND_STATUS.SUCCESS,
+      data: { redirectTo: sanitizeInternalRedirect(input.redirectTo) },
     }
   }
 }

--- a/lib/auth/password-login.ts
+++ b/lib/auth/password-login.ts
@@ -1,7 +1,12 @@
-import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, AUTH_UNAVAILABLE_STAGE, type AuthCommandResult } from "./contracts"
-import { sanitizeInternalRedirect } from "./redirects"
-import { parsePasswordLoginCredentials } from "./password-login-validation"
-import { createTemporarilyUnavailableError, type AuthUnavailableReporter } from "./temporarily-unavailable"
+import {
+  AUTH_COMMAND_STATUS,
+  AUTH_ERROR_CODE,
+  AUTH_UNAVAILABLE_STAGE,
+  type AuthCommandResult,
+} from "@/lib/auth/contracts"
+import { parsePasswordLoginCredentials } from "@/lib/auth/password-login-validation"
+import { sanitizeInternalRedirect } from "@/lib/auth/redirects"
+import { createTemporarilyUnavailableError, type AuthUnavailableReporter } from "@/lib/auth/temporarily-unavailable"
 
 export interface PasswordLoginInput {
   email: unknown

--- a/lib/auth/signup.ts
+++ b/lib/auth/signup.ts
@@ -1,5 +1,12 @@
-import { AUTH_ERROR_CODE, SIGN_UP_STATUS, type SignUpRateLimitScope, type SignUpResult } from "./contracts"
+import {
+  AUTH_ERROR_CODE,
+  AUTH_UNAVAILABLE_STAGE,
+  SIGN_UP_STATUS,
+  type SignUpRateLimitScope,
+  type SignUpResult,
+} from "./contracts"
 import { parseSignupInput } from "./signup-validation"
+import { createTemporarilyUnavailableError, type AuthUnavailableReporter } from "./temporarily-unavailable"
 
 export interface SignupInput {
   email: unknown
@@ -30,9 +37,10 @@ export interface SignupRateLimitAdapter {
 interface SignupDependencies {
   authAdapter: SignupAuthAdapter
   rateLimitAdapter: SignupRateLimitAdapter
+  reportUnavailable: AuthUnavailableReporter
 }
 
-export function createSignupCommand({ authAdapter, rateLimitAdapter }: SignupDependencies) {
+export function createSignupCommand({ authAdapter, rateLimitAdapter, reportUnavailable }: SignupDependencies) {
   return async function signup(input: SignupInput): Promise<SignUpResult> {
     const signupInput = parseSignupInput(input)
 
@@ -45,23 +53,34 @@ export function createSignupCommand({ authAdapter, rateLimitAdapter }: SignupDep
 
     const { email, password, fullName } = signupInput.data
 
+    let rateLimit: Awaited<ReturnType<SignupRateLimitAdapter["isAllowed"]>>
+
     try {
-      const rateLimit = await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp })
-
-      if (!rateLimit.allowed) {
-        return {
-          status: SIGN_UP_STATUS.ERROR,
-          error: {
-            code: AUTH_ERROR_CODE.RATE_LIMITED,
-            scope: rateLimit.scope,
-            remaining: rateLimit.remaining,
-            limit: rateLimit.limit,
-            reset: rateLimit.reset,
-          },
-        }
+      rateLimit = await rateLimitAdapter.isAllowed({ email, clientIp: input.clientIp })
+    } catch {
+      return {
+        status: SIGN_UP_STATUS.ERROR,
+        error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.RATE_LIMIT, reportUnavailable),
       }
+    }
 
-      return await authAdapter.signUp({
+    if (!rateLimit.allowed) {
+      return {
+        status: SIGN_UP_STATUS.ERROR,
+        error: {
+          code: AUTH_ERROR_CODE.RATE_LIMITED,
+          scope: rateLimit.scope,
+          remaining: rateLimit.remaining,
+          limit: rateLimit.limit,
+          reset: rateLimit.reset,
+        },
+      }
+    }
+
+    let result: SignUpResult
+
+    try {
+      result = await authAdapter.signUp({
         email,
         password,
         fullName,
@@ -70,8 +89,17 @@ export function createSignupCommand({ authAdapter, rateLimitAdapter }: SignupDep
     } catch {
       return {
         status: SIGN_UP_STATUS.ERROR,
-        error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+        error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.AUTH_PROVIDER, reportUnavailable),
       }
     }
+
+    if (result.status === SIGN_UP_STATUS.ERROR && result.error.code === AUTH_ERROR_CODE.PROVIDER_ERROR) {
+      return {
+        status: SIGN_UP_STATUS.ERROR,
+        error: createTemporarilyUnavailableError(AUTH_UNAVAILABLE_STAGE.AUTH_PROVIDER, reportUnavailable),
+      }
+    }
+
+    return result
   }
 }

--- a/lib/auth/signup.ts
+++ b/lib/auth/signup.ts
@@ -4,9 +4,9 @@ import {
   SIGN_UP_STATUS,
   type SignUpRateLimitScope,
   type SignUpResult,
-} from "./contracts"
-import { parseSignupInput } from "./signup-validation"
-import { createTemporarilyUnavailableError, type AuthUnavailableReporter } from "./temporarily-unavailable"
+} from "@/lib/auth/contracts"
+import { parseSignupInput } from "@/lib/auth/signup-validation"
+import { createTemporarilyUnavailableError, type AuthUnavailableReporter } from "@/lib/auth/temporarily-unavailable"
 
 export interface SignupInput {
   email: unknown

--- a/lib/auth/temporarily-unavailable.ts
+++ b/lib/auth/temporarily-unavailable.ts
@@ -1,0 +1,13 @@
+import { AUTH_ERROR_CODE, type AuthError, type AuthUnavailableStage } from "./contracts"
+
+export type AuthUnavailableReporter = (stage: AuthUnavailableStage) => string
+
+export function createTemporarilyUnavailableError(
+  stage: AuthUnavailableStage,
+  reportUnavailable: AuthUnavailableReporter
+): Extract<AuthError, { code: typeof AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE }> {
+  return {
+    code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE,
+    reference: reportUnavailable(stage),
+  }
+}

--- a/lib/auth/temporarily-unavailable.ts
+++ b/lib/auth/temporarily-unavailable.ts
@@ -1,4 +1,4 @@
-import { AUTH_ERROR_CODE, type AuthError, type AuthUnavailableStage } from "./contracts"
+import { AUTH_ERROR_CODE, type AuthError, type AuthUnavailableStage } from "@/lib/auth/contracts"
 
 export type AuthUnavailableReporter = (stage: AuthUnavailableStage) => string
 

--- a/lib/config/rate-limit-environment.d.mts
+++ b/lib/config/rate-limit-environment.d.mts
@@ -1,0 +1,7 @@
+export interface RateLimitEnvironment {
+  UPSTASH_REDIS_REST_URL?: string
+  UPSTASH_REDIS_REST_TOKEN?: string
+  KEEPEL_RATE_LIMIT_HMAC_SECRET?: string
+}
+
+export function validateRateLimitEnvironment(environment?: RateLimitEnvironment): void

--- a/lib/config/rate-limit-environment.mjs
+++ b/lib/config/rate-limit-environment.mjs
@@ -1,0 +1,13 @@
+const MINIMUM_SECRET_LENGTH = 32
+const CONFIGURATION_ERROR = "Rate-limit server environment is not configured."
+
+export function validateRateLimitEnvironment(environment = process.env) {
+  if (
+    !environment.UPSTASH_REDIS_REST_URL ||
+    !environment.UPSTASH_REDIS_REST_TOKEN ||
+    !environment.KEEPEL_RATE_LIMIT_HMAC_SECRET ||
+    environment.KEEPEL_RATE_LIMIT_HMAC_SECRET.length < MINIMUM_SECRET_LENGTH
+  ) {
+    throw new Error(CONFIGURATION_ERROR)
+  }
+}

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,10 +1,8 @@
 import { Ratelimit } from "@upstash/ratelimit"
 import { Redis } from "@upstash/redis"
+import { validateRateLimitEnvironment } from "@/lib/config/rate-limit-environment.mjs"
 
-// Validamos que las variables de entorno existan para evitar errores silenciosos en producción
-if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
-  throw new Error("Redis credentials are not defined in environment variables.")
-}
+validateRateLimitEnvironment()
 
 // Rate Limiter para LOGIN: 5 intentos cada 60 segundos (1 minuto)
 export const loginRateLimiter = new Ratelimit({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 import { getRequiredConsentSigningSecret } from "./lib/privacy/config.mjs"
+import { validateRateLimitEnvironment } from "./lib/config/rate-limit-environment.mjs"
 
 getRequiredConsentSigningSecret()
+validateRateLimitEnvironment()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/tests/e2e/auth/password-and-signup.spec.ts
+++ b/tests/e2e/auth/password-and-signup.spec.ts
@@ -26,6 +26,19 @@ test("invalid password credentials show stable user-facing feedback", async ({ p
   await expect(page).toHaveURL(/\/auth\/login$/)
 })
 
+test("a rate-limit outage blocks password login with an incident reference", async ({ page, request }) => {
+  await resetControlledServices(request, "success", "error")
+  await page.goto("/auth/login")
+  await page.getByLabel("Email").fill("driver@keepel.test")
+  await page.getByLabel("Contraseña").fill("correct-horse")
+  await page.getByRole("button", { name: "Iniciar Sesión", exact: true }).click()
+
+  const alert = page.getByRole("alert").filter({ hasText: "Ocurrió un error inesperado." })
+  await expect(alert).toContainText("Ocurrió un error inesperado. Inténtalo de nuevo.")
+  await expect(alert).toContainText(/Referencia: [0-9a-f-]{36}/)
+  await expect(page).toHaveURL(/\/auth\/login$/)
+})
+
 test("signup requiring email confirmation leads to the confirmation instructions", async ({ page }) => {
   await page.goto("/auth/signup")
   await page.getByLabel("Nombre Completo").fill("Grace Mechanic")
@@ -37,4 +50,19 @@ test("signup requiring email confirmation leads to the confirmation instructions
   await expect(page).toHaveURL(/\/auth\/signup-success$/)
   await expect(page.getByText("¡Cuenta Creada Exitosamente!", { exact: true })).toBeVisible()
   await expect(page.getByText("Verifica tu email para continuar", { exact: true })).toBeVisible()
+})
+
+test("a rate-limit outage blocks signup with an incident reference", async ({ page, request }) => {
+  await resetControlledServices(request, "success", "error")
+  await page.goto("/auth/signup")
+  await page.getByLabel("Nombre Completo").fill("Grace Mechanic")
+  await page.getByLabel("Email").fill("grace@keepel.test")
+  await page.getByLabel("Contraseña", { exact: true }).fill("correct-horse")
+  await page.getByLabel("Confirmar Contraseña").fill("correct-horse")
+  await page.getByRole("button", { name: "Crear Cuenta", exact: true }).click()
+
+  const alert = page.getByRole("alert").filter({ hasText: "Ocurrió un error inesperado." })
+  await expect(alert).toContainText("Ocurrió un error inesperado. Inténtalo de nuevo.")
+  await expect(alert).toContainText(/Referencia: [0-9a-f-]{36}/)
+  await expect(page).toHaveURL(/\/auth\/signup$/)
 })

--- a/tests/e2e/support/controlled-services-config.ts
+++ b/tests/e2e/support/controlled-services-config.ts
@@ -4,7 +4,12 @@ export const APP_URL = "http://localhost:3100"
 export const CONTROLLED_SERVICES_URL = "http://127.0.0.1:54321"
 
 export type ControlledOAuthMode = "success" | "cancel" | "provider_error" | "exchange_error"
+export type ControlledRateLimitMode = "success" | "error"
 
-export async function resetControlledServices(request: APIRequestContext, oauthMode: ControlledOAuthMode = "success") {
-  await request.post(`${CONTROLLED_SERVICES_URL}/__test__/reset`, { data: { oauthMode } })
+export async function resetControlledServices(
+  request: APIRequestContext,
+  oauthMode: ControlledOAuthMode = "success",
+  rateLimitMode: ControlledRateLimitMode = "success"
+) {
+  await request.post(`${CONTROLLED_SERVICES_URL}/__test__/reset`, { data: { oauthMode, rateLimitMode } })
 }

--- a/tests/e2e/support/controlled-services.ts
+++ b/tests/e2e/support/controlled-services.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-console -- Controlled E2E service reports startup and request failures. */
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
-import { APP_URL, CONTROLLED_SERVICES_URL, type ControlledOAuthMode } from "./controlled-services-config"
+import {
+  APP_URL,
+  CONTROLLED_SERVICES_URL,
+  type ControlledOAuthMode,
+  type ControlledRateLimitMode,
+} from "./controlled-services-config"
 
 const controlledServicesUrl = new URL(CONTROLLED_SERVICES_URL)
 const HOST = controlledServicesUrl.hostname
@@ -27,6 +32,7 @@ const sessions = new Map<string, ControlledUser>()
 const analyticsEvents: unknown[] = []
 let sessionSequence = 0
 let oauthMode: ControlledOAuthMode = "success"
+let rateLimitMode: ControlledRateLimitMode = "success"
 
 function corsHeaders() {
   return {
@@ -148,7 +154,7 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
   }
 
   if (request.method === "POST" && url.pathname === "/__test__/reset") {
-    const body = (await readJson(request)) as { oauthMode?: unknown } | null
+    const body = (await readJson(request)) as { oauthMode?: unknown; rateLimitMode?: unknown } | null
     sessions.clear()
     analyticsEvents.length = 0
     sessionSequence = 0
@@ -156,6 +162,7 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
       body?.oauthMode === "cancel" || body?.oauthMode === "provider_error" || body?.oauthMode === "exchange_error"
         ? body.oauthMode
         : "success"
+    rateLimitMode = body?.rateLimitMode === "error" ? "error" : "success"
     sendJson(response, 200, { ok: true })
     return
   }
@@ -275,6 +282,11 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
   }
 
   if (request.method === "POST" && url.pathname === "/pipeline") {
+    if (rateLimitMode === "error") {
+      sendJson(response, 503, { message: "Controlled Redis failure" })
+      return
+    }
+
     const commands = await readJson(request)
     const results = Array.isArray(commands) ? commands.map(handleRedis) : []
     sendJson(response, 200, results)
@@ -282,6 +294,11 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
   }
 
   if (request.method === "POST" && url.pathname === "/") {
+    if (rateLimitMode === "error") {
+      sendJson(response, 503, { message: "Controlled Redis failure" })
+      return
+    }
+
     sendJson(response, 200, handleRedis(await readJson(request)))
     return
   }

--- a/tests/integration/auth/action-failures.test.ts
+++ b/tests/integration/auth/action-failures.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE, SIGN_UP_STATUS } from "@/lib/auth/contracts"
+import type { loginAction as LoginAction, signupAction as SignupAction } from "@/app/auth/actions"
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => {
+    throw new Error("raw-boundary-failure")
+  }),
+}))
+vi.mock("@/lib/analytics/anonymous-analytics", () => ({ recordAnonymousAnalytics: vi.fn() }))
+vi.mock("@/lib/auth/server", () => ({
+  getCurrentUser: vi.fn(async () => null),
+  requireCurrentUser: vi.fn(),
+}))
+
+let loginAction: typeof LoginAction
+let signupAction: typeof SignupAction
+
+beforeAll(async () => {
+  vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://redis.example.com")
+  vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token")
+  vi.stubEnv("KEEPEL_RATE_LIMIT_HMAC_SECRET", "test-rate-limit-secret-that-is-long-enough")
+
+  const actions = await import("@/app/auth/actions")
+  loginAction = actions.loginAction
+  signupAction = actions.signupAction
+})
+
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
+describe("auth action failures", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    ["login", () => loginAction(null, new FormData()), AUTH_COMMAND_STATUS.ERROR],
+    ["signup", () => signupAction(null, new FormData()), SIGN_UP_STATUS.ERROR],
+  ])("sanitizes unexpected %s boundary failures with a correlatable reference", async (_name, run, status) => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    const result = await run()
+
+    expect(result).toEqual({
+      status,
+      error: {
+        code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE,
+        reference: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      },
+    })
+    expect(consoleError).toHaveBeenCalledWith("Authentication temporarily unavailable.", {
+      reference: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      stage: "action",
+    })
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("raw-boundary-failure")
+  })
+})

--- a/tests/integration/auth/password-login-feedback.test.ts
+++ b/tests/integration/auth/password-login-feedback.test.ts
@@ -17,4 +17,18 @@ describe("password login feedback", () => {
     expect(markup).toContain('role="alert"')
     expect(markup).toContain(expectedMessage)
   })
+
+  it("shows the incident reference for temporary unavailability", () => {
+    const markup = renderToStaticMarkup(
+      createElement(PasswordLoginFeedback, {
+        error: {
+          code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE,
+          reference: "auth-incident-login",
+        },
+      })
+    )
+
+    expect(markup).toContain("Ocurrió un error inesperado. Inténtalo de nuevo.")
+    expect(markup).toContain("Referencia: auth-incident-login")
+  })
 })

--- a/tests/integration/auth/password-login-flow.test.ts
+++ b/tests/integration/auth/password-login-flow.test.ts
@@ -59,6 +59,7 @@ describe("password login flow", () => {
           return true
         },
       },
+      reportUnavailable: () => "unused-auth-incident",
     })
     const navigatedTo: string[] = []
     const formData = new FormData()

--- a/tests/integration/auth/password-login.test.ts
+++ b/tests/integration/auth/password-login.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   createPasswordLoginCommand,
   type PasswordLoginAuthAdapter,
   type PasswordLoginRateLimitAdapter,
 } from "@/lib/auth/password-login"
 import { AUTH_COMMAND_STATUS, AUTH_ERROR_CODE } from "@/lib/auth/contracts"
+
+const unusedUnavailableReporter = () => "unused-auth-incident"
 
 describe("password login", () => {
   it("returns the stable invalid-credentials code without exposing the provider error", async () => {
@@ -18,7 +20,11 @@ describe("password login", () => {
         return true
       },
     }
-    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter })
+    const login = createPasswordLoginCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await login({
       email: "driver@example.com",
@@ -45,7 +51,11 @@ describe("password login", () => {
         return email !== "driver@example.com"
       },
     }
-    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter })
+    const login = createPasswordLoginCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await login({
       email: "  Driver@Example.com  ",
@@ -60,7 +70,7 @@ describe("password login", () => {
     })
   })
 
-  it("converts unexpected server failures into the stable unexpected code", async () => {
+  it("reports provider failures as temporarily unavailable with an incident reference", async () => {
     const authAdapter: PasswordLoginAuthAdapter = {
       async signInWithPassword() {
         throw new Error("provider connection failed")
@@ -71,7 +81,8 @@ describe("password login", () => {
         return true
       },
     }
-    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter })
+    const reportUnavailable = vi.fn(() => "auth-incident-login")
+    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter, reportUnavailable })
 
     const result = await login({
       email: "driver@example.com",
@@ -82,8 +93,65 @@ describe("password login", () => {
 
     expect(result).toEqual({
       status: AUTH_COMMAND_STATUS.ERROR,
-      error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+      error: { code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE, reference: "auth-incident-login" },
     })
+    expect(reportUnavailable).toHaveBeenCalledExactlyOnceWith("auth_provider")
+  })
+
+  it("reports a rejected provider result as the same unavailable outcome", async () => {
+    const authAdapter: PasswordLoginAuthAdapter = {
+      async signInWithPassword() {
+        return { authenticated: false, errorCode: AUTH_ERROR_CODE.PROVIDER_ERROR }
+      },
+    }
+    const rateLimitAdapter: PasswordLoginRateLimitAdapter = {
+      async isAllowed() {
+        return true
+      },
+    }
+    const reportUnavailable = vi.fn(() => "auth-incident-provider-result")
+    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter, reportUnavailable })
+
+    const result = await login({
+      email: "driver@example.com",
+      password: "secret-password",
+      clientIp: "203.0.113.10",
+      redirectTo: "/vehicles",
+    })
+
+    expect(result).toEqual({
+      status: AUTH_COMMAND_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE, reference: "auth-incident-provider-result" },
+    })
+    expect(reportUnavailable).toHaveBeenCalledExactlyOnceWith("auth_provider")
+  })
+
+  it("reports rate-limit dependency failures without attempting authentication", async () => {
+    const authAdapter: PasswordLoginAuthAdapter = {
+      async signInWithPassword() {
+        throw new Error("authentication should not run")
+      },
+    }
+    const rateLimitAdapter: PasswordLoginRateLimitAdapter = {
+      async isAllowed() {
+        throw new Error("redis unavailable")
+      },
+    }
+    const reportUnavailable = vi.fn(() => "auth-incident-rate-limit")
+    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter, reportUnavailable })
+
+    const result = await login({
+      email: "driver@example.com",
+      password: "secret-password",
+      clientIp: "203.0.113.10",
+      redirectTo: "/vehicles",
+    })
+
+    expect(result).toEqual({
+      status: AUTH_COMMAND_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE, reference: "auth-incident-rate-limit" },
+    })
+    expect(reportUnavailable).toHaveBeenCalledExactlyOnceWith("rate_limit")
   })
 
   it("rejects malformed credentials before crossing server boundaries", async () => {
@@ -97,7 +165,11 @@ describe("password login", () => {
         throw new Error("rate limiting should not run")
       },
     }
-    const login = createPasswordLoginCommand({ authAdapter, rateLimitAdapter })
+    const login = createPasswordLoginCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await login({
       email: "not-an-email",

--- a/tests/integration/auth/signup-feedback.test.ts
+++ b/tests/integration/auth/signup-feedback.test.ts
@@ -16,6 +16,20 @@ describe("signup feedback", () => {
     expect(markup).toContain(expectedMessage)
   })
 
+  it("shows the incident reference for temporary unavailability", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SignupFeedback, {
+        error: {
+          code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE,
+          reference: "auth-incident-signup",
+        },
+      })
+    )
+
+    expect(markup).toContain("Ocurrió un error inesperado. Inténtalo de nuevo.")
+    expect(markup).toContain("Referencia: auth-incident-signup")
+  })
+
   it.each([
     [SIGN_UP_RATE_LIMIT_SCOPE.IP, "Demasiados intentos de registro desde esta IP. Intenta más tarde."],
     [

--- a/tests/integration/auth/signup-flow.test.ts
+++ b/tests/integration/auth/signup-flow.test.ts
@@ -63,6 +63,7 @@ describe("signup flow", () => {
           return { allowed: true }
         },
       },
+      reportUnavailable: () => "unused-auth-incident",
     })
     const navigatedTo: string[] = []
     const formData = new FormData()
@@ -151,6 +152,7 @@ describe("signup flow", () => {
           return { allowed: true }
         },
       },
+      reportUnavailable: () => "unused-auth-incident",
     })
     const navigatedTo: string[] = []
     const formData = new FormData()

--- a/tests/integration/auth/signup.test.ts
+++ b/tests/integration/auth/signup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   AUTH_ERROR_CODE,
   SIGN_UP_RATE_LIMIT_SCOPE,
@@ -7,6 +7,8 @@ import {
   type UserId,
 } from "@/lib/auth/contracts"
 import { createSignupCommand, type SignupAuthAdapter, type SignupRateLimitAdapter } from "@/lib/auth/signup"
+
+const unusedUnavailableReporter = () => "unused-auth-incident"
 
 describe("signup", () => {
   it("returns the public user when signup creates an immediate session", async () => {
@@ -25,7 +27,11 @@ describe("signup", () => {
         return { allowed: true }
       },
     }
-    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+    const signup = createSignupCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await signup({
       email: "driver@example.com",
@@ -50,7 +56,11 @@ describe("signup", () => {
         throw new Error("rate limiting should not run")
       },
     }
-    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+    const signup = createSignupCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await signup({
       email: "driver@example.com",
@@ -82,7 +92,11 @@ describe("signup", () => {
         throw new Error("rate limiting should not run")
       },
     }
-    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+    const signup = createSignupCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await signup({
       email,
@@ -118,7 +132,11 @@ describe("signup", () => {
           : { allowed: true }
       },
     }
-    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+    const signup = createSignupCommand({
+      authAdapter,
+      rateLimitAdapter,
+      reportUnavailable: unusedUnavailableReporter,
+    })
 
     const result = await signup({
       email: "  Driver@Example.com  ",
@@ -141,7 +159,7 @@ describe("signup", () => {
     })
   })
 
-  it("converts unexpected server failures into the stable unexpected code", async () => {
+  it("reports provider failures as temporarily unavailable with an incident reference", async () => {
     const authAdapter: SignupAuthAdapter = {
       async signUp() {
         throw new Error("provider connection failed")
@@ -152,7 +170,8 @@ describe("signup", () => {
         return { allowed: true }
       },
     }
-    const signup = createSignupCommand({ authAdapter, rateLimitAdapter })
+    const reportUnavailable = vi.fn(() => "auth-incident-signup")
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter, reportUnavailable })
 
     const result = await signup({
       email: "driver@example.com",
@@ -165,7 +184,68 @@ describe("signup", () => {
 
     expect(result).toEqual({
       status: SIGN_UP_STATUS.ERROR,
-      error: { code: AUTH_ERROR_CODE.UNEXPECTED },
+      error: { code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE, reference: "auth-incident-signup" },
     })
+    expect(reportUnavailable).toHaveBeenCalledExactlyOnceWith("auth_provider")
+  })
+
+  it("reports a rejected provider result as the same unavailable outcome", async () => {
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        return { status: SIGN_UP_STATUS.ERROR, error: { code: AUTH_ERROR_CODE.PROVIDER_ERROR } }
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed() {
+        return { allowed: true }
+      },
+    }
+    const reportUnavailable = vi.fn(() => "auth-incident-provider-result")
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter, reportUnavailable })
+
+    const result = await signup({
+      email: "driver@example.com",
+      password: "secret-password",
+      confirmPassword: "secret-password",
+      fullName: "Ada Driver",
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE, reference: "auth-incident-provider-result" },
+    })
+    expect(reportUnavailable).toHaveBeenCalledExactlyOnceWith("auth_provider")
+  })
+
+  it("reports rate-limit dependency failures without attempting signup", async () => {
+    const authAdapter: SignupAuthAdapter = {
+      async signUp() {
+        throw new Error("signup should not run")
+      },
+    }
+    const rateLimitAdapter: SignupRateLimitAdapter = {
+      async isAllowed() {
+        throw new Error("redis unavailable")
+      },
+    }
+    const reportUnavailable = vi.fn(() => "auth-incident-rate-limit")
+    const signup = createSignupCommand({ authAdapter, rateLimitAdapter, reportUnavailable })
+
+    const result = await signup({
+      email: "driver@example.com",
+      password: "secret-password",
+      confirmPassword: "secret-password",
+      fullName: "Ada Driver",
+      clientIp: "203.0.113.10",
+      emailRedirectTo: "https://keepel.example/auth/callback",
+    })
+
+    expect(result).toEqual({
+      status: SIGN_UP_STATUS.ERROR,
+      error: { code: AUTH_ERROR_CODE.TEMPORARILY_UNAVAILABLE, reference: "auth-incident-rate-limit" },
+    })
+    expect(reportUnavailable).toHaveBeenCalledExactlyOnceWith("rate_limit")
   })
 })

--- a/tests/integration/privacy/next-config-validation.test.ts
+++ b/tests/integration/privacy/next-config-validation.test.ts
@@ -4,9 +4,15 @@ import { describe, expect, it } from "vitest"
 
 const projectRoot = fileURLToPath(new URL("../../..", import.meta.url))
 const expectedError = "KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters."
+const validServerEnvironment = {
+  KEEPEL_CONSENT_SIGNING_SECRET: "consent-secret-that-is-long-enough",
+  KEEPEL_RATE_LIMIT_HMAC_SECRET: "rate-limit-secret-that-is-at-least-32-characters",
+  UPSTASH_REDIS_REST_TOKEN: "redis-token",
+  UPSTASH_REDIS_REST_URL: "https://redis.example.com",
+}
 
 function importNextConfig(secret?: string) {
-  const environment = { ...process.env }
+  const environment: NodeJS.ProcessEnv = { ...process.env, ...validServerEnvironment }
 
   if (secret === undefined) {
     delete environment.KEEPEL_CONSENT_SIGNING_SECRET
@@ -24,13 +30,18 @@ function importNextConfig(secret?: string) {
 describe("Next privacy configuration", () => {
   it.each([undefined, "too-short"])("fails while loading when the consent secret is invalid", (secret) => {
     const result = importNextConfig(secret)
+    const output = `${result.stdout}${result.stderr}`
 
     expect(result.status).not.toBe(0)
-    expect(`${result.stdout}${result.stderr}`).toContain(expectedError)
+    expect(output).toContain(expectedError)
+
+    if (secret) {
+      expect(output).not.toContain(secret)
+    }
   })
 
   it("loads with a valid consent secret", () => {
-    const result = importNextConfig("consent-secret-that-is-long-enough")
+    const result = importNextConfig(validServerEnvironment.KEEPEL_CONSENT_SIGNING_SECRET)
 
     expect(result.status).toBe(0)
     expect(result.stderr).toBe("")

--- a/tests/integration/privacy/next-config-validation.test.ts
+++ b/tests/integration/privacy/next-config-validation.test.ts
@@ -3,7 +3,8 @@ import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
 const projectRoot = fileURLToPath(new URL("../../..", import.meta.url))
-const expectedError = "KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters."
+const expectedConsentError = "KEEPEL_CONSENT_SIGNING_SECRET must be defined and contain at least 32 characters."
+const expectedRateLimitError = "Rate-limit server environment is not configured."
 const validServerEnvironment = {
   KEEPEL_CONSENT_SIGNING_SECRET: "consent-secret-that-is-long-enough",
   KEEPEL_RATE_LIMIT_HMAC_SECRET: "rate-limit-secret-that-is-at-least-32-characters",
@@ -11,13 +12,17 @@ const validServerEnvironment = {
   UPSTASH_REDIS_REST_URL: "https://redis.example.com",
 }
 
-function importNextConfig(secret?: string) {
+type ServerEnvironmentOverrides = Partial<Record<keyof typeof validServerEnvironment, string | undefined>>
+
+function importNextConfig(overrides: ServerEnvironmentOverrides = {}) {
   const environment: NodeJS.ProcessEnv = { ...process.env, ...validServerEnvironment }
 
-  if (secret === undefined) {
-    delete environment.KEEPEL_CONSENT_SIGNING_SECRET
-  } else {
-    environment.KEEPEL_CONSENT_SIGNING_SECRET = secret
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete environment[name]
+    } else {
+      environment[name] = value
+    }
   }
 
   return spawnSync("node", ["--input-type=module", "--eval", 'await import("./next.config.mjs")'], {
@@ -29,21 +34,40 @@ function importNextConfig(secret?: string) {
 
 describe("Next privacy configuration", () => {
   it.each([undefined, "too-short"])("fails while loading when the consent secret is invalid", (secret) => {
-    const result = importNextConfig(secret)
+    const result = importNextConfig({ KEEPEL_CONSENT_SIGNING_SECRET: secret })
     const output = `${result.stdout}${result.stderr}`
 
     expect(result.status).not.toBe(0)
-    expect(output).toContain(expectedError)
+    expect(output).toContain(expectedConsentError)
 
     if (secret) {
       expect(output).not.toContain(secret)
     }
   })
 
-  it("loads with a valid consent secret", () => {
-    const result = importNextConfig(validServerEnvironment.KEEPEL_CONSENT_SIGNING_SECRET)
+  it("loads with a complete valid server environment", () => {
+    const result = importNextConfig()
 
     expect(result.status).toBe(0)
     expect(result.stderr).toBe("")
+  })
+})
+
+describe("Next rate-limit configuration", () => {
+  it.each([
+    ["UPSTASH_REDIS_REST_URL", undefined],
+    ["UPSTASH_REDIS_REST_TOKEN", undefined],
+    ["KEEPEL_RATE_LIMIT_HMAC_SECRET", undefined],
+    ["KEEPEL_RATE_LIMIT_HMAC_SECRET", "too-short"],
+  ] as const)("fails while loading when %s is invalid", (name, value) => {
+    const result = importNextConfig({ [name]: value })
+    const output = `${result.stdout}${result.stderr}`
+
+    expect(result.status).not.toBe(0)
+    expect(output).toContain(expectedRateLimitError)
+
+    if (value) {
+      expect(output).not.toContain(value)
+    }
   })
 })

--- a/tests/unit/config/rate-limit-environment.test.ts
+++ b/tests/unit/config/rate-limit-environment.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { validateRateLimitEnvironment } from "@/lib/config/rate-limit-environment.mjs"
+
+const validEnvironment = {
+  UPSTASH_REDIS_REST_URL: "https://redis.example.com",
+  UPSTASH_REDIS_REST_TOKEN: "redis-token",
+  KEEPEL_RATE_LIMIT_HMAC_SECRET: "rate-limit-secret-that-is-at-least-32-characters",
+}
+
+describe("rate-limit server environment", () => {
+  it.each([
+    ["UPSTASH_REDIS_REST_URL", undefined],
+    ["UPSTASH_REDIS_REST_TOKEN", ""],
+    ["KEEPEL_RATE_LIMIT_HMAC_SECRET", "too-short"],
+  ] as const)("rejects an invalid %s before the application starts", (name, value) => {
+    expect(() => validateRateLimitEnvironment({ ...validEnvironment, [name]: value })).toThrow(
+      "Rate-limit server environment is not configured."
+    )
+  })
+
+  it("accepts complete rate-limit server configuration", () => {
+    expect(validateRateLimitEnvironment(validEnvironment)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Handle rate-limit and authentication-provider outages as a typed, fail-closed authentication result. Users retain the existing generic Spanish message and receive an opaque incident reference, while server diagnostics record only a safe stage and reference.

The branch now incorporates the privacy-consent changes from `main` and verifies that both fail-fast configuration requirements compose correctly.

## Changes

- Validate Upstash credentials and `KEEPEL_RATE_LIMIT_HMAC_SECRET` during build/startup and rate-limit module loading.
- Map login and signup dependency failures to `temporarily_unavailable` with UUID correlation references.
- Remove raw exception logging from authentication Server Action boundaries.
- Extend the domain glossary with login-attempt and incident-reference terminology.
- Add unit, integration, Server Action boundary, feedback, and controlled Redis-outage E2E coverage.
- Use one complete valid server-environment baseline when importing the full Next.js configuration in isolated tests.
- Cover missing/short consent and rate-limit configuration independently without weakening either validator.
- Align new authentication imports with the documented `@/` alias.

## Security and configuration

- Authentication remains fail closed when anti-abuse protection is unavailable.
- Logs exclude email, IP, passwords, tokens, and raw provider messages.
- Deployments require `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, and a `KEEPEL_RATE_LIMIT_HMAC_SECRET` of at least 32 characters.
- Consent and rate-limit signing secrets remain independent and server-only. Preview and production should use environment-specific values.

## Testing

- `bun lint`
- `bun type-check`
- `bun run test` — 169 passed
- `bun run test:e2e -- tests/e2e/auth tests/e2e/privacy` — 19 passed
- `bun run build`
- Two-axis code review — no findings

`bun fmt:check` still reports the pre-existing formatting of `.engram/config.json`; that file is unchanged by this PR. The E2E run also emits the pre-existing vehicle-dialog hydration warning while all journeys pass.

## Related issues

- Implements #69
- Implements #70
- Relates to #68